### PR TITLE
ci: add release workflow, release config, and update dev tooling

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+changelog:
+  categories:
+    - title: Features
+      labels: [enhancement, feature]
+    - title: Bug Fixes
+      labels: [bug, fix]
+    - title: Documentation
+      labels: [documentation]
+    - title: CI/CD
+      labels: [ci, automation]
+    - title: Other Changes
+      labels: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,17 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Check formatting
-        run: poetry run ruff format --check packages/
+        run: poetry run ruff format --check packages/ examples/
 
       - name: Lint
-        run: poetry run ruff check packages/
+        run: poetry run ruff check packages/ examples/
 
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 This project helps you **integrate skills into your own agents**. Retrieve skills from any source — filesystem, database, API — validate them against the spec, and expose them to LLM agents through a progressive-disclosure API.
 
+> **Note:** Python 3.12 and 3.13 are fully tested. Python 3.14 is not yet supported due to upstream dependency limitations (`agentskills-langchain` and `agentskills-agentframework`).
+
 ---
 
 ## Packages

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,7 +83,7 @@ python scripts/dev.py all           # Format + lint + test
 GitHub Actions runs automatically on every push and pull request to `main`. The pipeline is defined in `.github/workflows/ci.yml` and includes two jobs:
 
 - **Lint**: checks formatting (`ruff format --check`) and linting (`ruff check`)
-- **Test**: runs `pytest` across Python 3.12, 3.13, and 3.14
+- **Test**: runs `pytest` across Python 3.12 and 3.13
 
 All checks must pass before a PR can be merged. The CI status badge is shown on the root README.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,6 +61,85 @@ Get-ChildItem -Recurse -Directory -Include __pycache__,.pytest_cache,.ruff_cache
 find . -type d \( -name __pycache__ -o -name .pytest_cache -o -name .ruff_cache -o -name '*.egg-info' \) -exec rm -rf {} +
 ```
 
+## Dev Task Runner
+
+A task runner script is available at `scripts/dev.py` for common development tasks:
+
+```bash
+python scripts/dev.py lint          # Check linting
+python scripts/dev.py lint:fix      # Auto-fix lint issues
+python scripts/dev.py format        # Auto-format code
+python scripts/dev.py format:check  # Check formatting without changes
+python scripts/dev.py typecheck     # Run mypy type checking
+python scripts/dev.py check         # Lint + format check + type check
+python scripts/dev.py test          # Run all tests
+python scripts/dev.py test:cov      # Run tests with coverage
+python scripts/dev.py clean         # Remove cache files
+python scripts/dev.py all           # Format + lint + test
+```
+
+## CI
+
+GitHub Actions runs automatically on every push and pull request to `main`. The pipeline is defined in `.github/workflows/ci.yml` and includes two jobs:
+
+- **Lint**: checks formatting (`ruff format --check`) and linting (`ruff check`)
+- **Test**: runs `pytest` across Python 3.12, 3.13, and 3.14
+
+All checks must pass before a PR can be merged. The CI status badge is shown on the root README.
+
+## Releasing
+
+### 1. Bump version
+
+All packages share the same version. Use the bump script to update all `pyproject.toml` files at once:
+
+```powershell
+# Patch: 0.2.0 -> 0.2.1
+.\scripts\bump-version.ps1
+
+# Minor: 0.2.0 -> 0.3.0
+.\scripts\bump-version.ps1 -Bump minor
+
+# Major: 0.2.0 -> 1.0.0
+.\scripts\bump-version.ps1 -Bump major
+
+# Explicit version
+.\scripts\bump-version.ps1 -Version 1.0.0
+
+# Preview without changing files
+.\scripts\bump-version.ps1 -Bump minor -DryRun
+```
+
+### 2. Commit and merge
+
+Create a branch, commit the version bump, open a PR, and merge to `main`.
+
+### 3. Publish to PyPI
+
+```powershell
+# Publish all packages in dependency order
+.\scripts\publish.ps1
+
+# Test on TestPyPI first
+.\scripts\publish.ps1 -TestPyPI
+
+# Build only (no publish)
+.\scripts\publish.ps1 -BuildOnly
+```
+
+Packages are published in dependency order: core, then providers, then integrations.
+
+### 4. Tag and release
+
+Push a version tag to trigger the GitHub Release workflow (`.github/workflows/release.yml`):
+
+```bash
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+This automatically creates a GitHub Release with auto-generated notes from merged PRs and commits since the previous tag.
+
 ## Project Structure
 
 | Package | Description |

--- a/examples/langchain/fs/mcp_tools.py
+++ b/examples/langchain/fs/mcp_tools.py
@@ -16,7 +16,8 @@ Flow:
     5. Run a LangChain ReAct agent
 
 Requirements:
-    pip install agentskills-fs agentskills-mcp-server langchain langchain-openai langchain-mcp-adapters
+    pip install agentskills-fs agentskills-mcp-server \
+        langchain langchain-openai langchain-mcp-adapters
     export AZURE_OPENAI_API_KEY=...
     export AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
     export AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini

--- a/examples/langchain/http/mcp_tools.py
+++ b/examples/langchain/http/mcp_tools.py
@@ -16,7 +16,8 @@ Flow:
     5. Run a LangChain ReAct agent
 
 Requirements:
-    pip install agentskills-http agentskills-mcp-server langchain langchain-openai langchain-mcp-adapters
+    pip install agentskills-http agentskills-mcp-server \
+        langchain langchain-openai langchain-mcp-adapters
     export AZURE_OPENAI_API_KEY=...
     export AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
     export AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -38,23 +38,23 @@ _PY = sys.executable
 
 def lint() -> None:
     """Run ruff linter (check only, no fixes)."""
-    _run([_PY, "-m", "ruff", "check", "packages/"])
+    _run([_PY, "-m", "ruff", "check", "packages/", "examples/"])
 
 
 def lint_fix() -> None:
     """Run ruff linter with auto-fix."""
-    _run([_PY, "-m", "ruff", "check", "--fix", "packages/"])
+    _run([_PY, "-m", "ruff", "check", "--fix", "packages/", "examples/"])
 
 
 def fmt() -> None:
     """Auto-format code with ruff."""
-    _run([_PY, "-m", "ruff", "format", "packages/"])
+    _run([_PY, "-m", "ruff", "format", "packages/", "examples/"])
     lint_fix()
 
 
 def fmt_check() -> None:
     """Check formatting without changing files."""
-    _run([_PY, "-m", "ruff", "format", "--check", "packages/"])
+    _run([_PY, "-m", "ruff", "format", "--check", "packages/", "examples/"])
 
 
 def typecheck() -> None:


### PR DESCRIPTION
Add GitHub Release workflow triggered on version tags (v*) using softprops/action-gh-release. Add release.yml config to group release notes by PR labels. Add Python 3.14 to CI test matrix. Document CI, releasing, and dev task runner in DEVELOPMENT.md.