### PR TITLE
Add AgentSkillsMcpContextProvider and bump agent-framework to rc3

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,9 +20,11 @@ LangChain and Microsoft Agent Framework examples organized by **provider** and *
 | `agent-framework/fs/local_context_provider.py` | Filesystem | Context provider | Skills loaded from disk, injected automatically via `AgentSkillsContextProvider` |
 | `agent-framework/http/local_context_provider.py` | HTTP | Context provider | Skills fetched from a URL, injected automatically via `AgentSkillsContextProvider` |
 | `agent-framework/fs/local_tools.py` | Filesystem | Agent Framework native | Skills loaded from disk, converted to Agent Framework tools directly |
-| `agent-framework/fs/mcp_tools.py` | Filesystem | MCP via Agent Framework | Skills served by an MCP server, consumed through `MCPStdioTool` |
+| `agent-framework/fs/mcp_tools.py` | Filesystem | MCP via Agent Framework | Skills served by an MCP server, consumed through `MCPStdioTool` (manual resource reading) |
+| `agent-framework/fs/mcp_context_provider.py` | Filesystem | MCP context provider | Skills served by an MCP server, injected automatically via `AgentSkillsMcpContextProvider` |
 | `agent-framework/http/local_tools.py` | HTTP | Agent Framework native | Skills fetched from a URL, converted to Agent Framework tools directly |
-| `agent-framework/http/mcp_tools.py` | HTTP | MCP via Agent Framework | Skills served by an MCP server (HTTP-backed), consumed through `MCPStdioTool` |
+| `agent-framework/http/mcp_tools.py` | HTTP | MCP via Agent Framework | Skills served by an MCP server (HTTP-backed), consumed through `MCPStdioTool` (manual resource reading) |
+| `agent-framework/http/mcp_context_provider.py` | HTTP | MCP context provider | Skills served by an MCP server (HTTP-backed), injected automatically via `AgentSkillsMcpContextProvider` |
 
 ## Local vs MCP Tools
 
@@ -34,6 +36,12 @@ setup; no server process needed.
 server. LangChain uses `langchain-mcp-adapters` to bridge those MCP tools;
 Agent Framework uses its built-in `MCPStdioTool`. Useful when you want a
 standard MCP server that any MCP client can connect to.
+
+**MCP context providers** (Agent Framework only) -
+`AgentSkillsMcpContextProvider` wraps an MCP session and automatically reads
+the skills catalog and usage instructions on every `agent.run()` call. This is
+the recommended MCP approach for Agent Framework — it removes the manual
+resource-reading boilerplate shown in the MCP tools examples.
 
 ## Prerequisites
 
@@ -66,6 +74,9 @@ pip install agentskills-http
 
 # For MCP examples
 pip install agentskills-mcp-server
+
+# For MCP context provider examples
+pip install agentskills-mcp-server[agentframework]
 
 # Agent Framework (required)
 pip install agent-framework --pre
@@ -152,12 +163,18 @@ python examples/agent-framework/http/local_context_provider.py
 # Filesystem - local tools
 python examples/agent-framework/fs/local_tools.py
 
-# Filesystem - MCP tools
+# Filesystem - MCP tools (manual resource reading)
 python examples/agent-framework/fs/mcp_tools.py
+
+# Filesystem - MCP context provider (recommended)
+python examples/agent-framework/fs/mcp_context_provider.py
 
 # HTTP - local tools (start the local HTTP server first, see above)
 python examples/agent-framework/http/local_tools.py
 
-# HTTP - MCP tools
+# HTTP - MCP tools (manual resource reading)
 python examples/agent-framework/http/mcp_tools.py
+
+# HTTP - MCP context provider (recommended, start the local HTTP server first)
+python examples/agent-framework/http/mcp_context_provider.py
 ```

--- a/examples/agent-framework/fs/mcp_context_provider.py
+++ b/examples/agent-framework/fs/mcp_context_provider.py
@@ -1,29 +1,33 @@
-"""Agent Framework agent with MCP tools — filesystem provider.
+"""Agent Framework agent with MCP context provider — filesystem provider.
 
 This script demonstrates connecting to an MCP server backed by a
-filesystem skill provider from an Agent Framework agent using the
-built-in MCPStdioTool.
+filesystem skill provider using ``AgentSkillsMcpContextProvider`` to
+automatically inject skills catalog and usage instructions into each
+agent run.
 
-The client never imports providers or registries — it only talks to the
-MCP server over stdio.  The server exposes skill content as MCP tools
-and the catalog / usage instructions as MCP resources.
+Unlike the manual approach in ``mcp_tools.py`` (which reads MCP
+resources directly), this example delegates prompt construction to
+:class:`~agentskills_mcp_server.AgentSkillsMcpContextProvider`.  The
+context provider reads the catalog and usage-instruction resources from
+the MCP session and injects them as session instructions on every
+``agent.run()`` call.
 
 Flow:
     1. Spawn an MCP server subprocess via ``python -m agentskills_mcp_server``
     2. Connect via MCPStdioTool (built into Agent Framework)
-    3. Read MCP resources for the system prompt (catalog + instructions)
-    4. Get tools automatically via MCPStdioTool
+    3. Create an ``AgentSkillsMcpContextProvider`` from the MCP session
+    4. Pass the context provider to the Agent constructor
     5. Run an Agent Framework agent with streaming
 
 Requirements:
-    pip install agentskills-fs agentskills-mcp-server agent-framework --pre
+    pip install agentskills-fs agentskills-mcp-server[agentframework] --pre
     export AZURE_OPENAI_API_KEY=...
     export AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
     export AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini
     export AZURE_OPENAI_API_VERSION=2024-12-01-preview
 
 Usage:
-    python examples/agent-framework/fs/mcp_tools.py
+    python examples/agent-framework/fs/mcp_context_provider.py
 """
 
 import asyncio
@@ -47,6 +51,13 @@ async def main() -> None:
         print("  pip install agent-framework --pre")
         return
 
+    try:
+        from agentskills_mcp_server import AgentSkillsMcpContextProvider
+    except ImportError:
+        print("[SKIP] agentskills-mcp-server[agentframework] not installed")
+        print("  pip install agentskills-mcp-server[agentframework]")
+        return
+
     python = sys.executable
 
     mcp_skills = MCPStdioTool(
@@ -63,22 +74,11 @@ async def main() -> None:
         print()
 
         # --------------------------------------------------------------
-        # 2. Read MCP resources for the system prompt
+        # 2. Create context provider from the MCP session
         # --------------------------------------------------------------
-        catalog_result = await mcp_skills.session.read_resource("skills://catalog/xml")
-        skills_catalog = catalog_result.contents[0].text
-
-        instructions_result = await mcp_skills.session.read_resource(
-            "skills://tools-usage-instructions"
+        skills_context = AgentSkillsMcpContextProvider(
+            session=mcp_skills.session,
         )
-        tools_usage_instructions = instructions_result.contents[0].text
-
-        print("=== Skills Catalog ===")
-        print(skills_catalog)
-        print()
-        print("=== Tool Usage Instructions ===")
-        print(tools_usage_instructions)
-        print()
 
         # --------------------------------------------------------------
         # 3. Initialize Agent Framework agent
@@ -92,20 +92,17 @@ async def main() -> None:
             print(f"[SKIP] LLM not available ({e})")
             return
 
-        system_prompt = (
-            "You are an SRE assistant. Use the available skill tools to "
-            "look up incident response procedures, severity definitions, "
-            "and escalation policies. Always cite which reference document "
-            "you used.\n\n"
-            f"{skills_catalog}\n\n"
-            f"{tools_usage_instructions}"
-        )
-
         agent = Agent(
             client=client,
             name="SREAssistant",
-            instructions=system_prompt,
+            instructions=(
+                "You are an SRE assistant. Use the available skill "
+                "tools to look up incident response procedures, "
+                "severity definitions, and escalation policies. "
+                "Always cite which reference document you used."
+            ),
             tools=mcp_skills,
+            context_providers=[skills_context],
         )
 
         # --------------------------------------------------------------

--- a/examples/agent-framework/http/mcp_context_provider.py
+++ b/examples/agent-framework/http/mcp_context_provider.py
@@ -1,29 +1,33 @@
-"""Agent Framework agent with MCP tools — filesystem provider.
+"""Agent Framework agent with MCP context provider — HTTP provider.
 
-This script demonstrates connecting to an MCP server backed by a
-filesystem skill provider from an Agent Framework agent using the
-built-in MCPStdioTool.
+This script demonstrates connecting to an MCP server backed by an HTTP
+static-file skill provider using ``AgentSkillsMcpContextProvider`` to
+automatically inject skills catalog and usage instructions into each
+agent run.
 
-The client never imports providers or registries — it only talks to the
-MCP server over stdio.  The server exposes skill content as MCP tools
-and the catalog / usage instructions as MCP resources.
+Unlike the manual approach in ``mcp_tools.py`` (which reads MCP
+resources directly), this example delegates prompt construction to
+:class:`~agentskills_mcp_server.AgentSkillsMcpContextProvider`.  The
+context provider reads the catalog and usage-instruction resources from
+the MCP session and injects them as session instructions on every
+``agent.run()`` call.
 
 Flow:
     1. Spawn an MCP server subprocess via ``python -m agentskills_mcp_server``
     2. Connect via MCPStdioTool (built into Agent Framework)
-    3. Read MCP resources for the system prompt (catalog + instructions)
-    4. Get tools automatically via MCPStdioTool
+    3. Create an ``AgentSkillsMcpContextProvider`` from the MCP session
+    4. Pass the context provider to the Agent constructor
     5. Run an Agent Framework agent with streaming
 
 Requirements:
-    pip install agentskills-fs agentskills-mcp-server agent-framework --pre
+    pip install agentskills-http agentskills-mcp-server[agentframework] --pre
     export AZURE_OPENAI_API_KEY=...
     export AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
     export AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini
     export AZURE_OPENAI_API_VERSION=2024-12-01-preview
 
 Usage:
-    python examples/agent-framework/fs/mcp_tools.py
+    python examples/agent-framework/http/mcp_context_provider.py
 """
 
 import asyncio
@@ -32,7 +36,7 @@ import sys
 from pathlib import Path
 
 # Path to the skills config file (relative to repo root)
-_CONFIG_FILE = Path(__file__).resolve().parent.parent.parent / "server-fs.json"
+_CONFIG_FILE = Path(__file__).resolve().parent.parent.parent / "server-http.json"
 
 
 async def main() -> None:
@@ -47,13 +51,20 @@ async def main() -> None:
         print("  pip install agent-framework --pre")
         return
 
+    try:
+        from agentskills_mcp_server import AgentSkillsMcpContextProvider
+    except ImportError:
+        print("[SKIP] agentskills-mcp-server[agentframework] not installed")
+        print("  pip install agentskills-mcp-server[agentframework]")
+        return
+
     python = sys.executable
 
     mcp_skills = MCPStdioTool(
         name="skills",
         command=python,
         args=["-m", "agentskills_mcp_server", "--config", str(_CONFIG_FILE)],
-        description="Agent Skills MCP server (filesystem provider)",
+        description="Agent Skills MCP server (HTTP provider)",
     )
 
     async with mcp_skills:
@@ -63,22 +74,11 @@ async def main() -> None:
         print()
 
         # --------------------------------------------------------------
-        # 2. Read MCP resources for the system prompt
+        # 2. Create context provider from the MCP session
         # --------------------------------------------------------------
-        catalog_result = await mcp_skills.session.read_resource("skills://catalog/xml")
-        skills_catalog = catalog_result.contents[0].text
-
-        instructions_result = await mcp_skills.session.read_resource(
-            "skills://tools-usage-instructions"
+        skills_context = AgentSkillsMcpContextProvider(
+            session=mcp_skills.session,
         )
-        tools_usage_instructions = instructions_result.contents[0].text
-
-        print("=== Skills Catalog ===")
-        print(skills_catalog)
-        print()
-        print("=== Tool Usage Instructions ===")
-        print(tools_usage_instructions)
-        print()
 
         # --------------------------------------------------------------
         # 3. Initialize Agent Framework agent
@@ -92,20 +92,17 @@ async def main() -> None:
             print(f"[SKIP] LLM not available ({e})")
             return
 
-        system_prompt = (
-            "You are an SRE assistant. Use the available skill tools to "
-            "look up incident response procedures, severity definitions, "
-            "and escalation policies. Always cite which reference document "
-            "you used.\n\n"
-            f"{skills_catalog}\n\n"
-            f"{tools_usage_instructions}"
-        )
-
         agent = Agent(
             client=client,
             name="SREAssistant",
-            instructions=system_prompt,
+            instructions=(
+                "You are an SRE assistant. Use the available skill "
+                "tools to look up incident response procedures, "
+                "severity definitions, and escalation policies. "
+                "Always cite which reference document you used."
+            ),
             tools=mcp_skills,
+            context_providers=[skills_context],
         )
 
         # --------------------------------------------------------------

--- a/examples/agent-framework/http/mcp_tools.py
+++ b/examples/agent-framework/http/mcp_tools.py
@@ -49,26 +49,26 @@ async def main() -> None:
 
     python = sys.executable
 
-    mcp_tool = MCPStdioTool(
+    mcp_skills = MCPStdioTool(
         name="skills",
         command=python,
         args=["-m", "agentskills_mcp_server", "--config", str(_CONFIG_FILE)],
         description="Agent Skills MCP server (HTTP provider)",
     )
 
-    async with mcp_tool:
-        print(f"=== MCP Tools ({len(mcp_tool.functions)}) ===")
-        for fn in mcp_tool.functions:
+    async with mcp_skills:
+        print(f"=== MCP Tools ({len(mcp_skills.functions)}) ===")
+        for fn in mcp_skills.functions:
             print(f"  - {fn.name}: {fn.description[:80] if fn.description else ''}")
         print()
 
         # --------------------------------------------------------------
         # 2. Read MCP resources for the system prompt
         # --------------------------------------------------------------
-        catalog_result = await mcp_tool.session.read_resource("skills://catalog/xml")
+        catalog_result = await mcp_skills.session.read_resource("skills://catalog/xml")
         skills_catalog = catalog_result.contents[0].text
 
-        instructions_result = await mcp_tool.session.read_resource(
+        instructions_result = await mcp_skills.session.read_resource(
             "skills://tools-usage-instructions"
         )
         tools_usage_instructions = instructions_result.contents[0].text
@@ -105,7 +105,7 @@ async def main() -> None:
             client=client,
             name="SREAssistant",
             instructions=system_prompt,
-            tools=mcp_tool,
+            tools=mcp_skills,
         )
 
         # --------------------------------------------------------------

--- a/packages/integrations/agentskills-agentframework/README.md
+++ b/packages/integrations/agentskills-agentframework/README.md
@@ -16,7 +16,7 @@ pip install agentskills-agentframework
 
 Requires Python 3.12 or 3.13. Installs `agentskills-core` and `agent-framework` as dependencies.
 
-> **Note:** `agent-framework` is currently a pre-release dependency (`>=1.0.0rc2`). The constraint will be updated once a stable release is published.
+> **Note:** `agent-framework` is currently a pre-release dependency (`>=1.0.0rc3`). The constraint will be updated once a stable release is published.
 
 ## Usage
 

--- a/packages/integrations/agentskills-agentframework/agentskills_agentframework/context_provider.py
+++ b/packages/integrations/agentskills-agentframework/agentskills_agentframework/context_provider.py
@@ -49,6 +49,23 @@ Use them when a task aligns with a skill's domain.
 {tools_usage_instructions}\
 """
 
+_PROMPT_VALIDATION_ERROR = (
+    "skills_instruction_prompt must contain {skills_catalog} and "
+    "{tools_usage_instructions} placeholders. "
+    "Escape literal braces by doubling them ({{ or }})."
+)
+
+
+def _validate_prompt_template(template: str) -> None:
+    """Validate that *template* contains the required placeholders."""
+    for placeholder in ("{skills_catalog}", "{tools_usage_instructions}"):
+        if placeholder not in template:
+            raise ValueError(_PROMPT_VALIDATION_ERROR)
+    try:
+        template.format(skills_catalog="", tools_usage_instructions="")
+    except (KeyError, IndexError, ValueError) as exc:
+        raise ValueError(_PROMPT_VALIDATION_ERROR) from exc
+
 
 class AgentSkillsContextProvider(BaseContextProvider):
     """Expose a :class:`~agentskills_core.SkillRegistry` to an Agent Framework agent.
@@ -116,24 +133,7 @@ class AgentSkillsContextProvider(BaseContextProvider):
         self._tools_usage_instructions = get_tools_usage_instructions()
 
         if skills_instruction_prompt is not None:
-            # Validate that the custom template has the required placeholders.
-            required = {"{skills_catalog}", "{tools_usage_instructions}"}
-            # Check presence of required placeholders (before format-escapes).
-            for placeholder in required:
-                if placeholder not in skills_instruction_prompt:
-                    raise ValueError(
-                        "skills_instruction_prompt must contain {skills_catalog} and "
-                        "{tools_usage_instructions} placeholders. "
-                        "Escape literal braces by doubling them ({{ or }})."
-                    )
-            try:
-                skills_instruction_prompt.format(skills_catalog="", tools_usage_instructions="")
-            except (KeyError, IndexError, ValueError) as exc:
-                raise ValueError(
-                    "skills_instruction_prompt must contain {skills_catalog} and "
-                    "{tools_usage_instructions} placeholders. "
-                    "Escape literal braces by doubling them ({{ or }})."
-                ) from exc
+            _validate_prompt_template(skills_instruction_prompt)
         self._skills_prompt_template = (
             skills_instruction_prompt or _DEFAULT_SKILLS_INSTRUCTION_PROMPT
         )

--- a/packages/integrations/agentskills-agentframework/pyproject.toml
+++ b/packages/integrations/agentskills-agentframework/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.12,<3.14"
 agentskills-core = ">=0.1.0,<1.0"
-# agent-framework >=1.0.0rc2 is required for BaseContextProvider / context_providers support.
+# agent-framework >=1.0.0rc3 is required for BaseContextProvider / context_providers support.
 # TODO: Remove allow-prereleases once a stable 1.0+ is available.
-agent-framework = {version = ">=1.0.0rc2,<2.0", allow-prereleases = true}
+agent-framework = {version = ">=1.0.0rc3,<2.0", allow-prereleases = true}
 
 [build-system]
 requires = ["poetry-core"]

--- a/packages/integrations/agentskills-mcp-server/agentskills_mcp_server/__init__.py
+++ b/packages/integrations/agentskills-mcp-server/agentskills_mcp_server/__init__.py
@@ -33,3 +33,14 @@ from agentskills_mcp_server.server import create_mcp_server
 __all__ = [
     "create_mcp_server",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazy-load optional extras to avoid hard dependencies at import time."""
+    if name == "AgentSkillsMcpContextProvider":
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        globals()["AgentSkillsMcpContextProvider"] = AgentSkillsMcpContextProvider
+        __all__.append("AgentSkillsMcpContextProvider")  # type: ignore[attr-defined]
+        return AgentSkillsMcpContextProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/integrations/agentskills-mcp-server/agentskills_mcp_server/context_provider.py
+++ b/packages/integrations/agentskills-mcp-server/agentskills_mcp_server/context_provider.py
@@ -1,0 +1,186 @@
+"""MCP-backed context provider for Agent Framework agents.
+
+Provides :class:`AgentSkillsMcpContextProvider`, a thin adapter that
+bridges an existing MCP session into the Agent Framework
+:class:`~agent_framework.BaseContextProvider` lifecycle.  It reads the
+skills catalog and usage-instruction resources from the MCP server and
+injects them as session instructions on every ``agent.run()`` call.
+
+**Tools are not injected by this adapter.** Agent Framework's MCP tool
+classes (:class:`~agent_framework.MCPStdioTool`,
+:class:`~agent_framework.MCPStreamableHttpTool`, etc.) already handle
+tool registration natively.  An MCP tool instance may also expose
+non-skill tools, so this adapter cannot reliably filter them.
+
+Usage::
+
+    from agent_framework import Agent, MCPStdioTool
+    from agentskills_mcp_server import AgentSkillsMcpContextProvider
+
+    mcp_skills = MCPStdioTool(
+        name="skills",
+        command="python",
+        args=["-m", "agentskills_mcp_server", "--config", "server.json"],
+    )
+
+    async with mcp_skills:
+        skills_context = AgentSkillsMcpContextProvider(
+            session=mcp_skills.session,
+        )
+        agent = client.as_agent(
+            name="SREAssistant",
+            instructions="You are an SRE assistant.",
+            tools=mcp_skills,
+            context_providers=[skills_context],
+        )
+        response = await agent.run("What severity is a full DB outage?")
+
+This module requires ``agent-framework`` at runtime.  Install via::
+
+    pip install agentskills-mcp-server[agentframework]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+try:
+    from agent_framework import BaseContextProvider
+except ImportError as _exc:
+    raise ImportError(
+        "AgentSkillsMcpContextProvider requires agent-framework. "
+        "Install it with:  pip install agentskills-mcp-server[agentframework]"
+    ) from _exc
+
+if TYPE_CHECKING:
+    from agent_framework import AgentSession, SessionContext, SupportsAgentRun
+    from mcp import ClientSession
+
+#: Resource URIs served by ``agentskills-mcp-server``.
+_CATALOG_URI_TEMPLATE = "skills://catalog/{format}"
+_INSTRUCTIONS_URI = "skills://tools-usage-instructions"
+
+_DEFAULT_SKILLS_INSTRUCTION_PROMPT = """\
+You have access to a set of skills that provide domain-specific \
+knowledge, procedures, and supporting resources. \
+Use them when a task aligns with a skill's domain.
+
+{skills_catalog}
+
+{tools_usage_instructions}\
+"""
+
+_PROMPT_VALIDATION_ERROR = (
+    "skills_instruction_prompt must contain {skills_catalog} and "
+    "{tools_usage_instructions} placeholders. "
+    "Escape literal braces by doubling them ({{ or }})."
+)
+
+
+def _validate_prompt_template(template: str) -> None:
+    """Validate that *template* contains the required placeholders."""
+    for placeholder in ("{skills_catalog}", "{tools_usage_instructions}"):
+        if placeholder not in template:
+            raise ValueError(_PROMPT_VALIDATION_ERROR)
+    try:
+        template.format(skills_catalog="", tools_usage_instructions="")
+    except (KeyError, IndexError, ValueError) as exc:
+        raise ValueError(_PROMPT_VALIDATION_ERROR) from exc
+
+
+class AgentSkillsMcpContextProvider(BaseContextProvider):
+    """Inject skills catalog and usage instructions from an MCP session.
+
+    This adapter reads two MCP resources on every ``agent.run()`` call
+    and appends them to the session context as instructions:
+
+    * ``skills://catalog/xml`` (or ``skills://catalog/markdown``) —
+      compact listing of registered skills.
+    * ``skills://tools-usage-instructions`` — guidance on the
+      progressive-disclosure workflow.
+
+    It does **not** inject tools.  Agent Framework's MCP tool classes
+    handle that natively.
+
+    Args:
+        session: An MCP :class:`~mcp.ClientSession`, typically
+            obtained via ``mcp_tool.session`` from an
+            :class:`~agent_framework.MCPStdioTool` or similar.
+
+    Keyword Args:
+        skills_instruction_prompt: Custom prompt template.  Must
+            contain ``{skills_catalog}`` and
+            ``{tools_usage_instructions}`` placeholders.  When
+            ``None``, a sensible default is used.
+        skills_catalog_format: Format for the skills catalog —
+            ``"xml"`` (default) or ``"markdown"``.
+        source_id: Unique identifier for this provider instance.
+
+    Example::
+
+        from agent_framework import MCPStdioTool
+        from agentskills_mcp_server import AgentSkillsMcpContextProvider
+
+        mcp_skills = MCPStdioTool(name="skills", command="python",
+                                  args=["-m", "agentskills_mcp_server",
+                                        "--config", "server.json"])
+        async with mcp_skills:
+            ctx_provider = AgentSkillsMcpContextProvider(
+                session=mcp_skills.session,
+            )
+    """
+
+    DEFAULT_SOURCE_ID: ClassVar[str] = "agentskills_mcp"
+
+    def __init__(
+        self,
+        session: ClientSession,
+        *,
+        skills_instruction_prompt: str | None = None,
+        skills_catalog_format: Literal["xml", "markdown"] = "xml",
+        source_id: str | None = None,
+    ) -> None:
+        super().__init__(source_id or self.DEFAULT_SOURCE_ID)
+        self._session = session
+        self._skills_catalog_format = skills_catalog_format
+
+        if skills_instruction_prompt is not None:
+            _validate_prompt_template(skills_instruction_prompt)
+        self._skills_prompt_template = (
+            skills_instruction_prompt or _DEFAULT_SKILLS_INSTRUCTION_PROMPT
+        )
+
+    async def before_run(
+        self,
+        *,
+        agent: SupportsAgentRun,
+        session: AgentSession,
+        context: SessionContext,
+        state: dict[str, Any],
+    ) -> None:
+        """Read MCP resources and inject skills instructions into the run context.
+
+        Reads the skills catalog and tools-usage-instructions resources
+        from the MCP session, formats them into the instruction prompt
+        template, and calls ``context.extend_instructions()``.
+
+        Args:
+            agent: The agent starting this run.
+            session: The active Agent Framework session.
+            context: Mutable run context to extend.
+            state: Provider-scoped mutable state persisted across runs.
+        """
+        catalog_uri = _CATALOG_URI_TEMPLATE.format(format=self._skills_catalog_format)
+
+        catalog_result = await self._session.read_resource(catalog_uri)
+        skills_catalog = catalog_result.contents[0].text
+
+        instructions_result = await self._session.read_resource(_INSTRUCTIONS_URI)
+        tools_usage_instructions = instructions_result.contents[0].text
+
+        skills_prompt = self._skills_prompt_template.format(
+            skills_catalog=skills_catalog,
+            tools_usage_instructions=tools_usage_instructions,
+        )
+
+        context.extend_instructions(self.source_id, skills_prompt)

--- a/packages/integrations/agentskills-mcp-server/pyproject.toml
+++ b/packages/integrations/agentskills-mcp-server/pyproject.toml
@@ -21,7 +21,7 @@ python = ">=3.12,<3.14"
 agentskills-core = ">=0.1.0"
 mcp = ">=1.0"
 pydantic = ">=2.0"
-agent-framework = {version = ">=1.0.0rc3,<2.0", optional = true}
+agent-framework = {version = ">=1.0.0rc3,<2.0", optional = true, allow-prereleases = true}
 
 [tool.poetry.extras]
 agentframework = ["agent-framework"]

--- a/packages/integrations/agentskills-mcp-server/pyproject.toml
+++ b/packages/integrations/agentskills-mcp-server/pyproject.toml
@@ -21,8 +21,10 @@ python = ">=3.12,<3.14"
 agentskills-core = ">=0.1.0"
 mcp = ">=1.0"
 pydantic = ">=2.0"
+agent-framework = {version = ">=1.0.0rc3,<2.0", optional = true}
 
 [tool.poetry.extras]
+agentframework = ["agent-framework"]
 fs = ["agentskills-fs"]
 http = ["agentskills-http"]
 

--- a/packages/integrations/agentskills-mcp-server/tests/test_context_provider.py
+++ b/packages/integrations/agentskills-mcp-server/tests/test_context_provider.py
@@ -1,0 +1,320 @@
+"""Tests for the AgentSkillsMcpContextProvider."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ------------------------------------------------------------------
+# Test helpers
+# ------------------------------------------------------------------
+
+
+def _mock_mcp_session(
+    catalog_text: str = "<available_skills>\n  <skill><name>incident-response</name>"
+    "<description>Handle production incidents.</description></skill>\n"
+    "</available_skills>",
+    instructions_text: str = "## How to Use Agent Skills\n\nUse `get_skill_metadata`.",
+) -> AsyncMock:
+    """Create a mock MCP ClientSession that returns resources."""
+    session = AsyncMock()
+
+    async def _read_resource(uri: str):
+        result = MagicMock()
+        content = MagicMock()
+        if "catalog" in str(uri):
+            content.text = catalog_text
+        elif "instructions" in str(uri):
+            content.text = instructions_text
+        else:
+            raise ValueError(f"Unknown resource URI: {uri}")
+        result.contents = [content]
+        return result
+
+    session.read_resource = AsyncMock(side_effect=_read_resource)
+    return session
+
+
+def _mock_context() -> MagicMock:
+    """Create a mock SessionContext with extend_instructions."""
+    ctx = MagicMock()
+    ctx.instructions = []
+
+    def _extend_instructions(source_id: str, instructions):
+        if isinstance(instructions, str):
+            instructions = [instructions]
+        ctx.instructions.extend(instructions)
+
+    ctx.extend_instructions = MagicMock(side_effect=_extend_instructions)
+    return ctx
+
+
+# ------------------------------------------------------------------
+# Tests: Construction
+# ------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_default_source_id(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        assert cp.source_id == "agentskills_mcp"
+
+    def test_custom_source_id(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session, source_id="my_mcp_skills")
+        assert cp.source_id == "my_mcp_skills"
+
+    def test_default_catalog_format(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        assert cp._skills_catalog_format == "xml"
+
+    def test_markdown_catalog_format(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session, skills_catalog_format="markdown")
+        assert cp._skills_catalog_format == "markdown"
+
+    def test_default_prompt_template(self):
+        from agentskills_mcp_server.context_provider import (
+            _DEFAULT_SKILLS_INSTRUCTION_PROMPT,
+            AgentSkillsMcpContextProvider,
+        )
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        assert cp._skills_prompt_template == _DEFAULT_SKILLS_INSTRUCTION_PROMPT
+
+    def test_custom_prompt_template(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        template = "Skills:\n{skills_catalog}\n\n{tools_usage_instructions}"
+        cp = AgentSkillsMcpContextProvider(session, skills_instruction_prompt=template)
+        assert cp._skills_prompt_template == template
+
+    def test_invalid_prompt_template_raises(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        with pytest.raises(ValueError, match="placeholders"):
+            AgentSkillsMcpContextProvider(session, skills_instruction_prompt="No placeholders here")
+
+    def test_prompt_template_with_escaped_braces(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(
+            session,
+            skills_instruction_prompt="{{literal}} {skills_catalog} {tools_usage_instructions}",
+        )
+        assert cp._skills_prompt_template is not None
+
+    def test_positional_placeholder_raises(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        with pytest.raises(ValueError, match="placeholders"):
+            AgentSkillsMcpContextProvider(
+                session,
+                skills_instruction_prompt="{} {skills_catalog} {tools_usage_instructions}",
+            )
+
+    def test_stray_opening_brace_raises(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        with pytest.raises(ValueError, match="placeholders"):
+            AgentSkillsMcpContextProvider(
+                session,
+                skills_instruction_prompt="{ {skills_catalog} {tools_usage_instructions}",
+            )
+
+    def test_stores_session(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        assert cp._session is session
+
+
+# ------------------------------------------------------------------
+# Tests: before_run — injection
+# ------------------------------------------------------------------
+
+
+class TestBeforeRun:
+    async def test_injects_instructions(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        ctx.extend_instructions.assert_called_once()
+        source_id, prompt = ctx.extend_instructions.call_args[0]
+        assert source_id == "agentskills_mcp"
+        assert "incident-response" in prompt
+
+    async def test_does_not_inject_tools(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        assert not hasattr(ctx, "extend_tools") or not ctx.extend_tools.called
+
+    async def test_reads_xml_catalog_by_default(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        # Verify catalog URI used
+        calls = session.read_resource.call_args_list
+        catalog_call = calls[0]
+        assert "catalog/xml" in str(catalog_call)
+
+    async def test_reads_markdown_catalog_when_configured(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session, skills_catalog_format="markdown")
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        calls = session.read_resource.call_args_list
+        catalog_call = calls[0]
+        assert "catalog/markdown" in str(catalog_call)
+
+    async def test_reads_instructions_resource(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        calls = session.read_resource.call_args_list
+        instructions_call = calls[1]
+        assert "tools-usage-instructions" in str(instructions_call)
+
+    async def test_custom_prompt_template(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(
+            session,
+            skills_instruction_prompt="BEGIN\n{skills_catalog}\nMIDDLE\n{tools_usage_instructions}\nEND",
+        )
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        _, prompt = ctx.extend_instructions.call_args[0]
+        assert prompt.startswith("BEGIN\n")
+        assert "\nMIDDLE\n" in prompt
+        assert prompt.endswith("\nEND")
+
+    async def test_default_prompt_includes_preamble(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        _, prompt = ctx.extend_instructions.call_args[0]
+        assert prompt.startswith("You have access to a set of skills")
+
+    async def test_includes_catalog_content(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session(
+            catalog_text="<available_skills><skill><name>my-skill</name></skill></available_skills>"
+        )
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        _, prompt = ctx.extend_instructions.call_args[0]
+        assert "my-skill" in prompt
+
+    async def test_includes_instructions_content(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session(instructions_text="Use get_skill_metadata to discover skills.")
+        cp = AgentSkillsMcpContextProvider(session)
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        _, prompt = ctx.extend_instructions.call_args[0]
+        assert "get_skill_metadata" in prompt
+
+    async def test_custom_source_id_in_call(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session, source_id="custom_src")
+        ctx = _mock_context()
+
+        await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+
+        source_id = ctx.extend_instructions.call_args[0][0]
+        assert source_id == "custom_src"
+
+
+# ------------------------------------------------------------------
+# Tests: Repeated calls (idempotency)
+# ------------------------------------------------------------------
+
+
+class TestRepeatedCalls:
+    async def test_before_run_can_be_called_multiple_times(self):
+        from agentskills_mcp_server.context_provider import AgentSkillsMcpContextProvider
+
+        session = _mock_mcp_session()
+        cp = AgentSkillsMcpContextProvider(session)
+
+        for _ in range(3):
+            ctx = _mock_context()
+            await cp.before_run(agent=MagicMock(), session=MagicMock(), context=ctx, state={})
+            ctx.extend_instructions.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Tests: Lazy import via __init__
+# ------------------------------------------------------------------
+
+
+class TestLazyImport:
+    def test_import_from_package(self):
+        from agentskills_mcp_server import AgentSkillsMcpContextProvider
+
+        assert AgentSkillsMcpContextProvider is not None
+
+    def test_unknown_attribute_raises(self):
+        import agentskills_mcp_server
+
+        with pytest.raises(AttributeError, match="no attribute"):
+            _ = agentskills_mcp_server.nonexistent_thing

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,18 +48,18 @@ pydantic = ">=2.11.2,<3.0.0"
 
 [[package]]
 name = "agent-framework"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 description = "Microsoft Agent Framework for building AI Agents with Python. This package contains all the core and optional packages."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "agent_framework-1.0.0rc2-py3-none-any.whl", hash = "sha256:9c8235676adb26f2d2c512abe71efb305ca07453a5ae9f290400fff8a9a8f288"},
-    {file = "agent_framework-1.0.0rc2.tar.gz", hash = "sha256:aac7a8861bc310458d41e0143d4c2dd975e2cd7f3bc3cd420fca78a3c879ddff"},
+    {file = "agent_framework-1.0.0rc3-py3-none-any.whl", hash = "sha256:2bdb844028ce24521ac20a069ae4af8b8957be64edbed51f3353f3772aac8be2"},
+    {file = "agent_framework-1.0.0rc3.tar.gz", hash = "sha256:c55c2d701799716a428c40a728a5b6eada074bb333fce12ff635fd845c35057c"},
 ]
 
 [package.dependencies]
-agent-framework-core = {version = "1.0.0rc2", extras = ["all"]}
+agent-framework-core = {version = "1.0.0rc3", extras = ["all"]}
 
 [[package]]
 name = "agent-framework-a2a"
@@ -233,14 +233,14 @@ microsoft-agents-copilotstudio-client = ">=0.3.1"
 
 [[package]]
 name = "agent-framework-core"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 description = "Microsoft Agent Framework for building AI Agents with Python. This is the core package that has all the core abstractions and implementations."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "agent_framework_core-1.0.0rc2-py3-none-any.whl", hash = "sha256:71293776a29360620924663338816151226bfa06d1793148f39f23e0d74964db"},
-    {file = "agent_framework_core-1.0.0rc2.tar.gz", hash = "sha256:2dd38775c9274e448485aaf2aca064f4bbaa0248650ee65535c9495e1eefd9f0"},
+    {file = "agent_framework_core-1.0.0rc3-py3-none-any.whl", hash = "sha256:e21b1353fdd70291869caa7c089270144a749b50408bd9822f882d9ed7fc00de"},
+    {file = "agent_framework_core-1.0.0rc3.tar.gz", hash = "sha256:0c35638e6add1d5b07c90ec3dafb94cc0763dd3ec1f62de4fb6598ff224cfa71"},
 ]
 
 [package.dependencies]
@@ -265,7 +265,7 @@ agent-framework-ollama = {version = "*", optional = true, markers = "extra == \"
 agent-framework-orchestrations = {version = "*", optional = true, markers = "extra == \"all\""}
 agent-framework-purview = {version = "*", optional = true, markers = "extra == \"all\""}
 agent-framework-redis = {version = "*", optional = true, markers = "extra == \"all\""}
-azure-ai-projects = "2.0.0b3"
+azure-ai-projects = "2.0.0b4"
 azure-identity = ">=1,<2"
 mcp = {version = ">=1.24.0,<2", extras = ["ws"]}
 openai = ">=1.99.0"
@@ -483,7 +483,7 @@ files = []
 develop = true
 
 [package.dependencies]
-agent-framework = ">=1.0.0rc2,<2.0"
+agent-framework = ">=1.0.0rc3,<2.0"
 agentskills-core = ">=0.1.0,<1.0"
 
 [package.source]
@@ -578,6 +578,7 @@ mcp = ">=1.0"
 pydantic = ">=2.0"
 
 [package.extras]
+agentframework = ["agent-framework (>=1.0.0rc3,<2.0)"]
 fs = []
 http = []
 
@@ -868,22 +869,23 @@ typing-extensions = ">=4.6.0"
 
 [[package]]
 name = "azure-ai-projects"
-version = "2.0.0b3"
+version = "2.0.0b4"
 description = "Microsoft Corporation Azure AI Projects Client Library for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "azure_ai_projects-2.0.0b3-py3-none-any.whl", hash = "sha256:3b3048a3ba3904d556ba392b7bd20b6e84c93bb39df6d43a6470cdb0ad08af8c"},
-    {file = "azure_ai_projects-2.0.0b3.tar.gz", hash = "sha256:6d09ad110086e450a47b991ee8a3644f1be97fa3085d5981d543f900d78f4505"},
+    {file = "azure_ai_projects-2.0.0b4-py3-none-any.whl", hash = "sha256:f4cf1615bd815744ddce304b97eea9456b7f6f0bd8725547c4e54e3a67534635"},
+    {file = "azure_ai_projects-2.0.0b4.tar.gz", hash = "sha256:b6082eacf0a11db59ad4c48cb7962f5204b9a0391000bc22421236f229ff783a"},
 ]
 
 [package.dependencies]
-azure-core = ">=1.35.0"
+azure-core = ">=1.37.0"
 azure-identity = ">=1.15.0"
 azure-storage-blob = ">=12.15.0"
 isodate = ">=0.6.1"
 openai = ">=2.8.0"
+typing-extensions = ">=4.11"
 
 [[package]]
 name = "azure-common"


### PR DESCRIPTION
Add AgentSkillsMcpContextProvider — a BaseContextProvider adapter that bridges an MCP session into the Agent Framework lifecycle. It reads the skills catalog and usage-instruction resources from the MCP server and injects them as session instructions on every agent.run() call. Tools are not injected; Agent Framework's MCP tool classes handle that natively.

Implementation:
- Add context_provider.py to agentskills-mcp-server with AgentSkillsMcpContextProvider(BaseContextProvider)
- Add [agentframework] optional extra to agentskills-mcp-server pyproject.toml pulling in agent-framework >=1.0.0rc3,<2.0
- Lazy-load AgentSkillsMcpContextProvider via __getattr__ in __init__.py to avoid hard agent-framework dependency at import time
- Inline prompt validation (_validate_prompt_template) in both context providers instead of sharing via agentskills-core
- Add 22 tests for MCP context provider (construction, before_run injection, idempotency, lazy import)

Examples:
- Add mcp_context_provider.py examples for both fs and http providers demonstrating the context_providers=[] approach
- Keep existing mcp_tools.py examples as the manual resource-reading approach
- Rename mcp_tool -> mcp_skills variable in existing mcp_tools.py examples
- Update examples/README.md with new table entries, MCP context providers section, install instructions, and run commands

Housekeeping:
- Bump agent-framework from rc2 to rc3 across all pyproject.toml files, README, and poetry.lock
- Add backlog item for provider content caching (redundant SKILL.md fetches)

All 327 tests pass, 1 skipped.