### PR TITLE
docs: add public roadmap, issue specifications, and ADRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,5 @@ htmlcov/
 # Environment
 .env
 
-# Backlog
-docs/backlog/
-
 # Distribution
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ Batch registration is atomic - if any skill fails validation, none are registere
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for setup, testing, linting, CI, releasing, and project structure.
 
+## Roadmap
+
+See [docs/ROADMAP.md](docs/ROADMAP.md) for planned themes, non-goals, and how work is tracked.
+
 ## Related Resources
 
 - [Agent Skills specification](https://agentskills.io/specification)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,177 @@
+# Agent Skills SDK — Roadmap
+
+> Public roadmap for the [Agent Skills SDK](../README.md). Themes and ordering, not dates.
+
+This document describes **what we intend to build and why**. It is intentionally coarse-grained:
+detailed scoping, discussion, and progress tracking live in
+[GitHub Issues](https://github.com/pratikxpanda/agentskills-sdk/issues), grouped by milestone.
+
+Written-up specifications for the items below — problem, approach, open questions, acceptance
+criteria — live in [docs/issues/](./issues/), one file per milestone.
+
+## Product Principles
+
+These constrain every item below. If a proposal conflicts with one of these, it needs an
+explicit design doc arguing the trade-off.
+
+1. **Spec-first.** The SDK implements the [Agent Skills open format](https://agentskills.io/specification).
+   We do not invent proprietary extensions to the skill format; where we need more (e.g. `version`),
+   we use optional, backward-compatible frontmatter fields and push for upstream adoption.
+2. **Progressive disclosure is the contract.** Every abstraction must let an agent pay only for
+   the tokens it actually needs. Anything that forces eager loading of full skill bodies is a bug.
+3. **Skills are untrusted code.** Skill content lands verbatim in an agent's context. Trust,
+   provenance, and integrity are first-class product features, not documentation footnotes.
+4. **Small, composable packages.** `agentskills-core` stays dependency-light. Providers and
+   framework integrations are optional installs and never leak into core.
+5. **Framework-agnostic core, thin adapters.** Framework-specific behaviour belongs in the
+   integration package. If two integrations need the same logic, it moves to core.
+
+## Themes
+
+| Theme | Why it matters |
+|---|---|
+| **Correctness & spec coverage** | Close the gaps between the SDK and the full skill format so real-world skills work unmodified. |
+| **Performance & resilience** | Skills are fetched on the hot path of an agent turn. Redundant I/O is latency and cost. |
+| **Agent effectiveness** | Retrieval is table stakes. The product question is whether an agent holding a skill actually performs better — and whether anyone can prove it. |
+| **Interoperability** | Teams already have instructions written in other formats. Meeting them where they are beats asking them to start over. |
+| **Trust & supply chain** | The differentiator for enterprise adoption. Skills are code; treat them like it. |
+| **Operability** | Platform teams cannot run what they cannot see. Logs, traces, metrics, usage signals. |
+| **Developer experience** | Adoption is gated on how fast someone can author, validate, and ship a skill. |
+| **Ecosystem breadth** | More providers and framework integrations widen the addressable surface. |
+| **Project health** | An open-source project is a product; release engineering and governance are features. |
+
+---
+
+## Now — v0.3 "Foundations"
+
+Close the highest-severity correctness and performance gaps before the API surface widens.
+
+| Item | Theme | Package(s) | Notes |
+|---|---|---|---|
+| Provider content caching | Performance | `agentskills-fs`, `agentskills-http` | A single skill's `SKILL.md` is fetched up to 5x per session — twice during registration (`validate_skill()` calls `get_body()` and `get_metadata()` independently), once per catalog build, and again on each tool call. For HTTP that is 5 network round-trips for one immutable file. Cache per provider instance; use `ETag` / `Last-Modified` conditional requests rather than a blind TTL. |
+| Concurrent catalog build | Performance | `agentskills-core` | `get_skills_catalog()` fetches metadata serially. Fan out with `asyncio.gather` and bounded concurrency. |
+| Non-blocking filesystem I/O | Performance | `agentskills-fs` | The provider is `async` but reads synchronously, blocking the event loop. Move to a thread executor. |
+| Resource discovery API | Correctness | `agentskills-core` + providers | No way for an agent to learn which references/scripts/assets exist. Add `list_resources(skill_id)` returning names by kind. Today discovery depends on SKILL.md prose. |
+| Binary-safe resources | Correctness | `agentskills-core` + all integrations | All three integrations decode provider bytes with `.decode("utf-8", errors="replace")`, silently destroying images, PDFs, and archives. Detect binary content and return a structured envelope instead; use MCP's native binary content blocks where the protocol supports them. |
+| Optional `version` frontmatter | Correctness | `agentskills-core` | Semver, validated when present, surfaced in `get_metadata()`. Prerequisite for Hub version pinning and for any dependency/compatibility story. |
+| HTTP error classification | Resilience | `agentskills-http` | Every non-2xx currently maps to `SkillNotFoundError`. Distinguish 404 from 5xx/timeouts via a new `SkillUnavailableError`, and add bounded retry with jittered backoff for retryable classes. |
+| Structured logging | Operability | all | Consistent `agentskills.*` logger namespace, no handlers attached by the library, never log secrets or URLs containing credentials. |
+| Coverage gate in CI | Project health | repo | `pytest-cov` with a floor, enforced in CI, badge in README. |
+| Automated PyPI publish | Project health | repo | Replace manual `publish.ps1` runs with GitHub Actions **Trusted Publishing** (OIDC, no long-lived tokens), triggered by the release tag. |
+
+---
+
+## Next — v0.4 "Developer Experience"
+
+Make authoring and validating skills a first-class workflow, and make third-party providers
+provably correct.
+
+| Item | Theme | Package(s) | Notes |
+|---|---|---|---|
+| `agentskills` CLI | DX | new `agentskills-cli` | `init` (scaffold a skill), `validate <path>` (spec check, exit non-zero on failure), `lint` (style/token-budget warnings), `inspect` (render catalog/metadata), `serve` (run the MCP server without writing config by hand). |
+| Skill validation GitHub Action | DX | repo | Thin wrapper over `agentskills validate` so skill repos can gate PRs. Highest-leverage adoption lever — it puts the SDK in other people's CI. |
+| Provider conformance test kit | Correctness | new `agentskills-testing` | A published pytest suite any third-party provider can run to prove it satisfies the `SkillProvider` contract (traversal safety, size limits, error types, resource listing). Turns the protocol into a real, testable interface. |
+| Test doubles | DX | `agentskills-testing` | `InMemorySkillProvider` + fixtures so downstream users can unit-test agents without disk or network. |
+| Registry-level discovery | DX | `agentskills-core` + providers | Optional `discover()` on providers, plus `registry.register_all(provider)`. Registering N skills currently requires knowing all N IDs up front. |
+| Catalog filtering & budget | DX / Perf | `agentskills-core` | `get_skills_catalog(tags=..., include=..., max_chars=...)`. The catalog is injected into every system prompt; it must not grow without bound. |
+| Skill evaluation harness | Agent effectiveness | `agentskills-testing` + CLI | `agentskills eval` — run a skill's test cases against a real model with and without the skill loaded, and report the delta. Skills are prompts, and today nobody measures whether one helps. Makes skill authoring an engineering activity instead of a matter of taste. |
+| Foreign format adapters | Interoperability | new `agentskills-adapters` | Import `AGENTS.md`, `.github/copilot-instructions.md`, Cursor rules, and Claude skill folders as `Skill` objects. An import layer, not a spec fork — it attacks the empty-registry problem, which is the real adoption barrier. |
+| Token cost reporting | DX | `agentskills-cli` | `agentskills inspect --cost` breaking down tokens by catalog entry, body section, and resource. Authors cannot budget what they cannot see. |
+| Documentation site | Project health | repo | MkDocs Material with API reference, versioned per release. README is already carrying more than it should. |
+| Architecture decision records | Project health | `docs/adr/` | Short ADRs for cross-package decisions (async model, caching strategy, error taxonomy, packaging). |
+
+---
+
+## Next — v0.5 "Agent Effectiveness"
+
+Everything before this makes skills safe and cheap to ship. This milestone is about making them
+**worth** shipping — the point where the SDK stops being a loader and starts changing how well the
+agent performs.
+
+| Item | Theme | Package(s) | Notes |
+|---|---|---|---|
+| Semantic skill selection | Agent effectiveness | new `agentskills-retrieval` | The catalog is injected on every turn, so prompt cost is linear in registered skills. Embed descriptions once, select top-k against the current turn, inject a handful. Descriptions are already written to be discriminative, so the corpus exists for free. Ships with a zero-dependency lexical default; embeddings are pluggable. Opt-in, and it must log its selection — this trades a deterministic prompt for a better one. |
+| Section-level disclosure | Agent effectiveness | `agentskills-core` + integrations | `get_skill_body()` is all-or-nothing, so a thorough 4k-token skill is charged in full to use one section. Split the body by heading, return an outline plus `get_skill_section(skill_id, heading)`. Extends progressive disclosure one level inward rather than adding a new idea, and stops penalising well-written skills. |
+| Stateful / session-aware disclosure | Agent effectiveness | `agentskills-agentframework` | Use the context provider's session `state` and `after_run` hook to track which skills the agent already loaded, prune the advertised catalog to the active domain, and inject resource-level tools only for loaded skills. Turns progressive disclosure into a framework-level behaviour rather than a prompt instruction. |
+| Vision-native assets | Agent effectiveness | integrations | Once binary resources are safe (v0.3), stop stringifying them: hand images to multimodal models as native content. A skill can then carry an architecture diagram or a UI screenshot that the model actually sees. |
+| Selection metadata | Correctness | `agentskills-core` | Optional `when_to_use` / `when_not_to_use` frontmatter. False activation is as damaging as non-activation, and a description alone carries no negative signal. Improves both LLM selection and retrieval ranking. Optional and backward-compatible per principle 1; push upstream. |
+| Single-skill fast path | Performance | integrations | When exactly one skill is registered or selected, inject the body directly instead of advertising a tool and waiting for the agent to call it. Removes a full round-trip from the common single-purpose-agent case. |
+
+---
+
+## Later — v0.6 "Trust & Operability"
+
+The enterprise story. This is the work that makes the SDK viable as the substrate for
+[Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub).
+
+| Item | Theme | Package(s) | Notes |
+|---|---|---|---|
+| Skill integrity & provenance | Trust | `agentskills-core` | Optional manifest with per-file SHA-256, verified on load. Then detached signature verification (Sigstore) and an "unverified skill" policy switch. Skills are code — this is the missing supply-chain control. |
+| Content policy pipeline | Trust | `agentskills-core` | Pluggable `SkillPolicy` hooks that run before content enters agent context: reject, redact, or annotate. Ships with a heuristic prompt-injection scanner and a max-token guard; enterprises plug in their own. |
+| `allowed-tools` enforcement | Trust | integrations | The field is validated but never enforced. Integrations should be able to constrain the agent's tool surface while a skill is active. |
+| SSRF hardening | Trust | `agentskills-http` | Host allow/deny lists, private/link-local IP range blocking by default, DNS-rebinding-aware connection checks. `require_tls` alone is not an SSRF control. |
+| Secret redaction | Trust | `agentskills-core`, `agentskills-http` | Central redaction helper applied to exception messages and log records so `Authorization` headers and SAS tokens never surface in tracebacks. |
+| OpenTelemetry instrumentation | Operability | `agentskills-core` + providers | Spans for fetch/parse/validate, metrics for fetch latency, cache hit ratio, and payload size. Optional dependency, no-op when OTel is absent. |
+| Skill usage telemetry hooks | Operability | `agentskills-core` | Callback protocol emitting "skill X disclosed at level Y". Answers the question every platform team asks: *which skills are actually being used?* Feeds Hub analytics directly. |
+| Startup health check | Resilience | `agentskills-core` | `registry.health()` verifying every provider is reachable and every skill parses, at boot. A misconfigured provider should fail deployment, not fail silently mid-conversation. |
+| Serve-stale on provider failure | Resilience | providers | If a refresh fails but cached content exists, serve the stale copy and flag it rather than failing the agent turn. A registry outage should degrade the agent, not break it. Builds on v0.3 caching and error classification. |
+
+---
+
+## Later — v0.7 "Ecosystem"
+
+Breadth, once the core contracts are stable enough that each new package is cheap to add.
+
+| Item | Theme | Notes |
+|---|---|---|
+| Skills as MCP prompts | Interoperability | The MCP server exposes skills as tools only. Many clients surface *prompts* as slash commands, so the same registry becomes user-invocable in Claude Desktop, VS Code, and others for very little work. |
+| Git provider | Ecosystem | Most skills live in Git repos. Clone/fetch with ref or commit pinning, sparse checkout, local cache. Likely the single most requested provider. |
+| Object storage provider | Ecosystem | S3 / Azure Blob / GCS via a common abstraction, with native credential chains instead of hand-rolled headers. |
+| OCI artifact provider | Ecosystem | Skills as OCI artifacts in any container registry — inherits existing signing, replication, and RBAC infrastructure. Pairs naturally with the integrity work in v0.5. |
+| Database provider | Ecosystem | Reference implementation over SQL for teams storing skills in an existing system of record. |
+| OpenAI Agents SDK integration | Ecosystem | Notable gap in the current integration matrix. |
+| Additional framework adapters | Ecosystem | Pydantic AI, Semantic Kernel, LlamaIndex, CrewAI. Prioritize by inbound demand rather than building all of them speculatively. |
+| Node/TypeScript port | Ecosystem | Large commitment. Only if there is clear pull — the MCP server already serves TS agents today, which may be sufficient. |
+
+---
+
+## v1.0 — Stability
+
+| Item | Notes |
+|---|---|
+| API freeze | Public surface documented and frozen; anything not documented is explicitly private. |
+| Compatibility policy | SemVer commitments, a written deprecation policy with a minimum support window, and coordinated cross-package version guarantees. |
+| Python 3.14 support | Currently blocked on upstream dependencies. Track with a nightly allow-failure CI matrix entry so we know the day it unblocks. |
+| Release automation end-to-end | Changelog generation, signed artifacts with build provenance/attestations, automated publish on tag. |
+| Hub interoperability | The SDK contracts the Hub depends on (versioning, integrity, telemetry, MCP gateway composition) are stable and documented. |
+
+---
+
+## Explicit Non-Goals
+
+Stating these prevents recurring proposals and scope creep.
+
+- **Executing skill scripts.** The SDK retrieves scripts; it does not run them. Sandboxed
+  execution is the host application's responsibility. We will document the hazard, not own it.
+- **Authoring or hosting UI.** That is [Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub)'s job.
+- **Authentication and authorization.** Providers accept caller-supplied credentials. The SDK
+  is not an identity or policy system.
+- **Being an agent framework.** We integrate with frameworks; we do not compete with them.
+- **Forking the skill format.** Divergence from the open spec is a last resort.
+
+---
+
+## How We Plan Work
+
+| Artifact | Purpose |
+|---|---|
+| **This roadmap** | Direction and sequencing. Reviewed at the start of each minor version. No dates. |
+| **GitHub Milestones** | One per minor version (`v0.3`, `v0.4`, …). An item is committed when it has an issue in a milestone. |
+| **GitHub Issues** | The single unit of work. Status, assignment, discussion, and linked PRs. Labelled by `theme:*`, `package:*`, `type:*`, and `good-first-issue`. |
+| **[docs/issues/](./issues/)** | The durable specification behind each roadmap item, one file per milestone. Filed issues link back here instead of duplicating the text; shipped items stay for the record. |
+| **GitHub Project board** | Now / Next / Later / Done view across issues, linked from the README. |
+| **[docs/adr/](./adr/)** | Short, immutable records of decisions already made and their trade-offs. Written when a decision is hard to reverse or likely to be questioned later. |
+
+**Contributing to the roadmap:** open a GitHub Discussion for an idea, or an issue for
+something concrete. Changes to a public contract should be agreed on the issue before a PR
+is opened. Items marked `good-first-issue` are the recommended entry point.

--- a/docs/adr/0001-mcp-context-provider-packaging.md
+++ b/docs/adr/0001-mcp-context-provider-packaging.md
@@ -1,0 +1,51 @@
+# ADR 0001 — MCP context provider lives in `agentskills-mcp-server` behind an extra
+
+**Status:** Accepted
+**Date:** 2026-02
+**Packages:** `agentskills-mcp-server`, `agentskills-agentframework`
+
+## Context
+
+There are two ways to connect a Microsoft Agent Framework agent to skills:
+
+- **In-process** — `AgentSkillsContextProvider(registry)` in `agentskills-agentframework`, wrapping a `SkillRegistry` directly.
+- **Out-of-process** — `agentskills-mcp-server` exposes skills as MCP tools and resources over stdio or HTTP.
+
+The MCP path required manual wiring: connect via one of Agent Framework's MCP tool classes, read the catalog resources, assemble the system prompt, pass the tools. Agent Framework's MCP tool classes register the tools automatically but do nothing about instructions, so the catalog had to be injected by hand on every agent.
+
+We needed a bridge, and had to decide where it lived. `agentskills-mcp-server` is deliberately framework-agnostic — it serves LangChain, custom agents, CLI clients, and anything else that speaks MCP. Adding a hard `agent-framework` dependency to it was not acceptable.
+
+## Decision
+
+`AgentSkillsMcpContextProvider` ships **inside `agentskills-mcp-server`, behind an optional `[agentframework]` extra**, rather than in `agentskills-agentframework` or a separate package.
+
+| Layer | Install | Role |
+| --- | --- | --- |
+| MCP server (core) | `agentskills-mcp-server` | Universal protocol layer, framework-agnostic |
+| MCP + AF adapter | `agentskills-mcp-server[agentframework]` | Adds the context provider, pulls in `agent-framework` |
+| In-process provider | `agentskills-agentframework` | Wraps a `SkillRegistry` directly |
+
+The adapter injects **instructions only**. It reads `skills://catalog/{format}` and `skills://tools-usage-instructions` from the MCP session and calls `context.extend_instructions()`.
+
+It deliberately does **not** inject or filter tools. Agent Framework's MCP tool classes already register MCP tools natively, and a given MCP server may expose tools beyond skills — the adapter has no reliable way to tell which tools are skill tools, so attempting to filter them would be guesswork.
+
+It also does not start or manage server processes, and does not import from `agentskills_mcp_server`'s server module. It only needs a generic MCP session, which makes it transport-agnostic across `MCPStdioTool`, `MCPSseTool`, and `MCPStreamableHttpTool`.
+
+## Consequences
+
+**Good**
+
+- The base MCP package stays framework-agnostic; `agent-framework` is only pulled in when someone opts into the extra.
+- Discoverable — MCP users find the adapter in the package they already installed, not a separate one they have to know exists.
+- No tool duplication or fragile tool filtering.
+- Works with any MCP transport, since only the session is required.
+
+**Costs**
+
+- `agentskills-mcp-server` now has framework-specific code in its tree, even though the dependency is optional. If a second framework adapter is ever needed, this pattern does not scale and the adapters should move to their own packages.
+- Prompt-template validation is duplicated between the two context providers. Acceptable for two call sites; extract to a shared helper if a third appears.
+
+## Alternatives considered
+
+- **Put it in `agentskills-agentframework`.** Rejected: that package's contract is "wrap a registry in-process". Adding an MCP-session-based provider would give it two unrelated entry points and an MCP dependency it otherwise does not need.
+- **A separate `agentskills-mcp-agentframework` package.** Rejected: a seventh package for one thin class, and users would have to discover it existed.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,0 +1,51 @@
+# Issue Specifications
+
+> Detailed write-ups for [roadmap](../ROADMAP.md) items, kept in the repo whether or not they
+> have been filed as GitHub issues yet.
+
+The roadmap says *what* and *why* in one line per item. These files carry the full
+specification: problem statement, proposed approach, open questions, and acceptance criteria.
+
+Each file covers one milestone, in the same order as the corresponding roadmap table.
+
+| Milestone | Items | State |
+|---|---|---|
+| [v0.3 — Foundations](./v0.3.md) | 10 | Specified |
+| [v0.4 — Developer Experience](./v0.4.md) | 11 | Specified |
+| [v0.5 — Agent Effectiveness](./v0.5.md) | 1 of 6 | Partly specified — the remaining items need design work first |
+| v0.6 — Trust & Operability | — | Not specified; see the [roadmap](../ROADMAP.md) |
+| v0.7 — Ecosystem | — | Not specified; see the [roadmap](../ROADMAP.md) |
+| v1.0 — Stability | — | Not specified; see the [roadmap](../ROADMAP.md) |
+
+A milestone only gets a file once its items are concrete enough to have acceptance criteria.
+The later ones are deliberately still one-liners on the roadmap.
+
+## Relationship to GitHub Issues
+
+| | Lives here | Lives on the issue |
+|---|---|---|
+| Problem statement, proposed design, acceptance criteria | yes | a link back to here |
+| Status, assignee, milestone, discussion, linked PRs | | yes |
+
+When an item is filed, add its number to the heading so the two stay connected:
+
+```markdown
+## 3. Stop blocking the event loop in the filesystem provider ([#42](https://github.com/pratikxpanda/agentskills-sdk/issues/42))
+```
+
+The issue body should link back to its section here rather than duplicating it — duplicated
+text is what drifts. If the design changes during implementation, **update the spec here**: the
+issue thread records the discussion, this file records the conclusion.
+
+Shipped items stay, marked `**Status:** Shipped in vX.Y`, so the reasoning behind a change
+remains findable. An item whose design turned out to be wrong gets a note explaining why rather
+than being quietly deleted.
+
+## Labels
+
+| Prefix | Values |
+|---|---|
+| `theme:` | `correctness`, `performance`, `resilience`, `agent-effectiveness`, `interoperability`, `trust`, `operability`, `dx`, `ecosystem`, `project-health` |
+| `package:` | `core`, `fs`, `http`, `langchain`, `agentframework`, `mcp-server`, `cli`, `testing`, `retrieval`, `adapters` |
+| `type:` | `bug`, `feature`, `docs`, `chore` |
+| flat | `good-first-issue`, `help-wanted`, `breaking-change` |

--- a/docs/issues/v0.3.md
+++ b/docs/issues/v0.3.md
@@ -1,0 +1,380 @@
+# v0.3 "Foundations"
+
+Specifications for the v0.3 roadmap items, in the same order as the table in the
+[roadmap](../ROADMAP.md). Milestone: `v0.3`.
+
+Add the GitHub issue number to a heading once the item is filed.
+
+---
+
+## 1. Cache `SKILL.md` content in providers
+
+**Labels:** `theme:performance`, `type:feature`, `package:fs`, `package:http`
+
+### Problem
+
+`LocalFileSystemSkillProvider` and `HTTPStaticFileSkillProvider` re-fetch and re-parse
+`SKILL.md` on **every** call to `get_metadata()` or `get_body()`. A single skill is read up
+to five times in one agent session:
+
+| # | Code path | Trigger |
+|---|---|---|
+| 1 | `validate_skill()` → `skill.get_body()` | Registration |
+| 2 | `validate_skill()` → `skill.get_metadata()` | Registration |
+| 3 | `registry.get_skills_catalog()` → `skill.get_metadata()` | System prompt / MCP resource read |
+| 4 | tool call → `skill.get_metadata()` | Agent turn |
+| 5 | tool call → `skill.get_body()` | Agent turn |
+
+For the HTTP provider that is five network round-trips for one file. For the filesystem
+provider the I/O is cheaper but the redundant YAML parsing remains.
+
+### Proposal
+
+Add a content cache keyed by `skill_id` to the internal `_get_skill_md()` / `_read_skill_md()`
+helper in both providers.
+
+```python
+self._skill_md_cache: dict[str, str] = {}
+
+async def _get_skill_md(self, skill_id: str) -> str:
+    if skill_id not in self._skill_md_cache:
+        self._skill_md_cache[skill_id] = await self._fetch(...)
+    return self._skill_md_cache[skill_id]
+```
+
+Cache is per provider instance. No public API change.
+
+For HTTP, prefer **conditional requests** (`If-None-Match` / `If-Modified-Since` using the
+stored `ETag` / `Last-Modified`) over a blind TTL — a `304` costs one cheap round-trip and
+keeps long-lived servers correct when a skill is republished. Expose an explicit
+`invalidate(skill_id=None)` for callers that need it.
+
+### Acceptance criteria
+
+- [ ] HTTP provider issues exactly one request per skill across a full register → catalog → tool-call flow (assert on mocked `httpx` call count)
+- [ ] Filesystem provider reads each `SKILL.md` once (spy on `Path.read_text`)
+- [ ] Cache is per-instance — two providers do not share state
+- [ ] `invalidate()` clears one skill or all
+- [ ] HTTP revalidates with `ETag`/`Last-Modified` and handles `304`
+- [ ] Existing tests pass unchanged
+
+### Related follow-ups (file separately if wanted)
+
+- `validate_skill()` calls `get_body()` and `get_metadata()` independently, parsing twice. Fetch and split once.
+- `SkillRegistry.get_skills_catalog()` re-derives metadata for every skill on each call; the registry has no `unregister()`, so the catalog string can be memoised.
+- Both providers duplicate `_get_skill_md()` → `split_frontmatter()`; a shared helper returning `tuple[dict, str]` avoids double parsing.
+
+---
+
+## 2. Build the skills catalog concurrently
+
+**Labels:** `theme:performance`, `type:feature`, `package:core`
+
+### Problem
+
+`SkillRegistry.get_skills_catalog()` awaits `get_metadata()` for each skill in sequence. With
+an HTTP-backed registry of N skills that is N serial round-trips on the critical path of the
+first agent turn.
+
+### Proposal
+
+Fan out with `asyncio.gather` and a bounded semaphore (default concurrency ~8, configurable).
+Preserve deterministic ordering by sorting results after the gather, not relying on completion
+order.
+
+### Acceptance criteria
+
+- [ ] Catalog output is byte-identical to the serial implementation for the same registry
+- [ ] Metadata fetches run concurrently (assert with an instrumented provider)
+- [ ] Concurrency is bounded and configurable
+- [ ] A failure in one skill's metadata surfaces with the offending `skill_id` in the message
+
+---
+
+## 3. Stop blocking the event loop in the filesystem provider
+
+**Labels:** `theme:performance`, `type:bug`, `package:fs`
+
+### Problem
+
+`LocalFileSystemSkillProvider` exposes an `async` interface but reads synchronously via
+`Path.read_text()` / `read_bytes()`. Every skill read blocks the event loop, which matters for
+servers handling concurrent agent sessions (including the MCP server in streamable-HTTP mode).
+
+### Proposal
+
+Move blocking I/O to a worker thread (`asyncio.to_thread`, or `anyio.to_thread.run_sync` to
+stay loop-agnostic). Keep the size check before the read where possible so oversized files are
+rejected without loading them.
+
+### Acceptance criteria
+
+- [ ] No blocking filesystem calls on the event loop
+- [ ] Size limit still enforced
+- [ ] Concurrent reads from one provider work correctly
+
+---
+
+## 4. Add resource discovery to the provider contract
+
+**Labels:** `theme:correctness`, `type:feature`, `package:core`, `package:fs`, `package:http`, `breaking-change`
+
+> **Blocked on a design decision** — see "Open question" below. Do not start implementation
+> until that is settled.
+
+### Problem
+
+There is no way for an agent to learn which references, scripts, or assets a skill contains.
+`get_reference(skill_id, name)` requires a name the agent can only obtain if `SKILL.md` happens
+to mention it in prose. Progressive disclosure is effectively half-blind: the agent can fetch
+a resource but cannot enumerate one.
+
+### Proposal
+
+Add to `SkillProvider`:
+
+```python
+async def list_resources(self, skill_id: str) -> dict[str, list[str]]:
+    """Return available resource names grouped by kind: references, scripts, assets."""
+```
+
+- **Filesystem:** list the `references/`, `scripts/`, `assets/` subdirectories, applying the same identifier-safety rules used on read.
+- **HTTP:** static servers cannot be enumerated. Suggest an optional per-skill `index.json` manifest — which also gives the supply-chain work a natural home for integrity hashes.
+- Surface as a `list_skill_resources` tool in each integration and as an MCP resource.
+
+### Open question
+
+Adding a required abstract method is a **breaking change** for any third-party `SkillProvider`.
+Options:
+
+1. Required abstract method — clean contract, breaks implementors.
+2. Default implementation returning `{}` plus a `supports_resource_listing` capability flag — backward-compatible, weaker contract.
+
+Recommend (2) pre-1.0, revisiting at the API freeze.
+
+### Acceptance criteria
+
+- [ ] Decision recorded as an ADR before implementation
+- [ ] `list_resources()` on the provider contract
+- [ ] Filesystem implementation, with traversal guards
+- [ ] HTTP behaviour decided and implemented
+- [ ] Exposed through LangChain, Agent Framework, and MCP integrations
+- [ ] Documented in each package README
+
+---
+
+## 5. Stop corrupting binary skill resources
+
+**Labels:** `theme:correctness`, `type:bug`, `package:core`, `package:langchain`, `package:agentframework`, `package:mcp-server`
+
+### Problem
+
+All three integrations decode provider bytes the same way:
+
+```python
+return (await skill.get_asset(name)).decode("utf-8", errors="replace")
+```
+
+For any non-text resource — a PNG, a PDF, a zip — `errors="replace"` turns the payload into a
+run of U+FFFD replacement characters. The data is destroyed, no exception is raised, and the
+agent receives garbage it cannot distinguish from a legitimately odd document. The package
+READMEs currently document this as a "Note", which presents silent data loss as intended
+behaviour.
+
+The skill spec allows `assets/` to hold arbitrary files, so this is reachable through the
+documented happy path rather than an edge case.
+
+### Proposal
+
+A shared `encode_resource_content()` in `agentskills-core`, used by all three integrations so
+the behaviour cannot drift apart again:
+
+1. Sniff for binary content (null byte within the first 8 KiB).
+2. If it looks like text, attempt a **strict** UTF-8 decode and return the string on success.
+3. Otherwise return a JSON envelope carrying the media type (via `mimetypes`) and base64 content:
+
+```json
+{
+  "name": "architecture.png",
+  "media_type": "image/png",
+  "size_bytes": 20481,
+  "encoding": "base64",
+  "content": "iVBORw0KGgo..."
+}
+```
+
+Base64 costs roughly 1.37x the raw bytes in characters, and a 1 MiB image would swamp a context
+window. Above a `max_inline_binary_bytes` ceiling (default 64 KiB, caller-overridable) return
+the same envelope with `"encoding": "none"` and a `note` explaining the omission, so the agent
+learns the resource exists and why it was not inlined.
+
+The strict decode in step 2 matters: it is what converts a silent corruption into a detected
+one. Falling back to the envelope on `UnicodeDecodeError` means no input path can produce
+replacement characters.
+
+### Open question
+
+MCP supports typed binary content blocks and resource links natively, so the JSON envelope is a
+lowest-common-denominator choice there. Options: ship the envelope everywhere first for
+consistency and specialise the MCP server afterwards, or diverge immediately. The envelope is
+the smaller change and keeps one code path; the MCP specialisation is worth doing but is a
+separate piece of work.
+
+### Acceptance criteria
+
+- [ ] No integration calls `.decode("utf-8", errors="replace")` on resource bytes
+- [ ] A PNG asset round-trips: `base64.b64decode(envelope["content"]) == original_bytes`
+- [ ] `media_type` inferred from the resource name
+- [ ] UTF-8 text resources unchanged, including non-ASCII
+- [ ] Text that is valid UTF-8 but contains a null byte still returns intact
+- [ ] Oversized binaries return `"encoding": "none"` with an explanatory note, not truncated content
+- [ ] `max_inline_binary_bytes` overridable on `get_tools()` and `create_mcp_server()`
+- [ ] READMEs describe the envelope; the existing "replacement characters" note is removed
+
+### Follow-up
+
+Once the envelope lands, have `create_mcp_server()` return binary resources as native MCP
+binary content blocks — or a resource link when oversized — rather than a JSON string the client
+has to parse. Text behaviour unchanged, and `encode_resource_content()` stays as-is for the
+non-MCP integrations.
+
+---
+
+## 6. Optional `version` field in skill frontmatter
+
+**Labels:** `theme:correctness`, `type:feature`, `package:core`
+
+### Problem
+
+Skills have no version. Consumers cannot pin, compare, or detect drift, and
+[Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub) needs versioned publishing
+and subscription pinning.
+
+### Proposal
+
+Optional `version` frontmatter field, validated as semver **when present**, surfaced through
+`get_metadata()` and included in the catalog. Fully backward-compatible — absence is valid.
+
+Raise the field with the upstream spec rather than shipping a silent proprietary extension.
+
+### Acceptance criteria
+
+- [ ] `version` validated as semver when present, ignored when absent
+- [ ] Returned by `get_metadata()`
+- [ ] Invalid semver fails registration with a clear message
+- [ ] Documented as an optional, non-spec field pending upstream adoption
+
+---
+
+## 7. Distinguish "not found" from "unavailable" in the HTTP provider
+
+**Labels:** `theme:resilience`, `type:bug`, `package:http`
+
+### Problem
+
+`HTTPStaticFileSkillProvider` maps every non-2xx response — and every transport failure — to
+`SkillNotFoundError`. A `503`, a DNS failure, and a genuine `404` are indistinguishable to the
+caller, so nobody can implement sensible retry or alerting. A transient blip currently looks
+like a missing skill.
+
+### Proposal
+
+- New `SkillUnavailableError(AgentSkillsError)` in core for transient/transport failures.
+- `404`/`410` → `SkillNotFoundError`. `5xx`, `429`, timeouts, connection errors → `SkillUnavailableError`.
+- `401`/`403` get a distinct message that does not echo credentials.
+- Bounded retry with exponential backoff and jitter for retryable classes only; honour `Retry-After`. Retry count and timeout configurable on the constructor.
+
+### Acceptance criteria
+
+- [ ] Error taxonomy implemented and documented in the package README error table
+- [ ] Retries only on retryable classes, with a cap
+- [ ] `Retry-After` honoured
+- [ ] No credential material in any exception message
+- [ ] Tests per status class via `respx`
+
+---
+
+## 8. Structured logging across the SDK
+
+**Labels:** `theme:operability`, `type:feature`, `package:core`, `package:fs`, `package:http`
+
+### Problem
+
+Outside one warning in `validation.py`, the SDK is silent. There is no way to see which skills
+were fetched, how long a fetch took, or why a provider fell back — which makes production
+support guesswork.
+
+### Proposal
+
+- Module-level loggers under a consistent `agentskills.*` namespace.
+- Library attaches **no handlers** and adds `NullHandler`; the host application configures output.
+- `DEBUG` for fetch/parse/cache events, `INFO` for registration outcomes, `WARNING` for degraded behaviour.
+- A redaction helper applied to anything containing a URL, header, or query string so `Authorization` values and SAS tokens never reach a log record. Pairs with the error messages in issue 7.
+
+### Acceptance criteria
+
+- [ ] Consistent logger namespace, `NullHandler` attached
+- [ ] No secret material in any log record (test with a provider configured with a bearer token and a SAS-style query param)
+- [ ] Logging conventions documented in `docs/DEVELOPMENT.md`
+
+---
+
+## 9. Enforce a coverage floor in CI
+
+**Labels:** `theme:project-health`, `type:chore`, `good-first-issue`
+
+### Problem
+
+`pytest-cov` is not a dev dependency and CI has no coverage gate, so regressions in test
+coverage are invisible.
+
+### Proposal
+
+Add `pytest-cov`, wire `python scripts/dev.py test:cov` into the CI test job, set a floor
+(start at current measured coverage, ratchet upward), publish the report, and add a badge.
+
+### Acceptance criteria
+
+- [ ] Coverage measured per package and in aggregate
+- [ ] CI fails below the floor
+- [ ] Badge in the root README
+
+---
+
+## 10. Automate PyPI publishing with Trusted Publishing
+
+**Labels:** `theme:project-health`, `type:chore`
+
+### Problem
+
+Releasing means a maintainer running `scripts/publish.ps1` locally with PyPI credentials, in
+dependency order, across six packages. It is manual, unauditable, requires a long-lived token
+on a workstation, and is easy to get half-done.
+
+### Proposal
+
+GitHub Actions workflow triggered by the release tag, using **PyPI Trusted Publishing** (OIDC,
+no stored token):
+
+- Build all six packages
+- Publish in dependency order: `core` → providers → integrations
+- Gate on a GitHub Environment requiring manual approval
+- Dry-run to TestPyPI on release-candidate tags
+- Attach build provenance attestations (prerequisite for artifact signing in v1.0)
+
+Keep `publish.ps1` for local/emergency use.
+
+### Acceptance criteria
+
+- [ ] Tag push publishes all six packages with no stored credentials
+- [ ] Dependency order enforced; a failure mid-sequence is clearly reported
+- [ ] TestPyPI path verified end-to-end
+- [ ] Release process in `docs/DEVELOPMENT.md` updated
+
+---
+
+## Unblocked side note
+
+`mypy` is referenced by `scripts/dev.py` and `docs/DEVELOPMENT.md` but is not installed in the
+dev environment, so `dev.py typecheck` and `dev.py check` fail. Worth folding into issue 9 or
+filing as a separate `type:chore`.

--- a/docs/issues/v0.4.md
+++ b/docs/issues/v0.4.md
@@ -1,0 +1,435 @@
+# v0.4 "Developer Experience"
+
+Specifications for the v0.4 roadmap items, in the same order as the table in the
+[roadmap](../ROADMAP.md). Milestone: `v0.4`.
+
+Add the GitHub issue number to a heading once the item is filed.
+
+---
+
+## 1. `agentskills` CLI
+
+**Labels:** `theme:dx`, `type:feature`, `package:cli`
+
+### Problem
+
+There is no way to work with a skill without writing Python. Validation only happens inside
+`registry.register()`, at runtime, in someone's application — so a malformed `SKILL.md` is
+discovered by an agent failing to start rather than by the author who wrote it. Authoring a new
+skill means copying an existing folder and hoping the frontmatter is right.
+
+### Proposal
+
+A new `agentskills-cli` package exposing an `agentskills` entry point.
+
+| Command | Behaviour |
+|---|---|
+| `agentskills init <name>` | Scaffold `SKILL.md` with valid frontmatter plus empty `references/`, `scripts/`, `assets/` folders. |
+| `agentskills validate <path>` | Run `validate_skill()` against one skill or a directory of them. Human-readable output by default, `--format json` for machines. **Exit non-zero on failure** — this is the contract CI depends on. |
+| `agentskills lint <path>` | Non-fatal quality warnings: description too long for a catalog, body over a token budget, resources present but never referenced from the body, missing `version`. |
+| `agentskills inspect <path>` | Render what an agent would actually see — the catalog entry, the metadata, the body — so authors can check token cost before shipping. |
+| `agentskills serve <path>` | Run the MCP server over a folder of skills without hand-writing a `server.json`. |
+
+Keep the dependency footprint small; the CLI should install without pulling in any framework
+integration.
+
+### Open questions
+
+- Separate package, or an extra on `agentskills-core` (`pip install agentskills-core[cli]`)? A separate package keeps core dependency-light, which is a stated product principle.
+- Which argument parser — stdlib `argparse` (no dependency) or `typer`/`click` (nicer UX, extra dependency)?
+
+### Acceptance criteria
+
+- [ ] All five commands implemented with `--help`
+- [ ] `validate` exits non-zero on any failure and zero on success
+- [ ] `validate` handles both a single skill folder and a directory of skills
+- [ ] `--format json` output is stable and documented
+- [ ] Installs without any framework integration dependency
+- [ ] Package README with examples
+
+---
+
+## 2. Skill validation GitHub Action
+
+**Labels:** `theme:dx`, `type:feature`
+
+**Depends on:** item 1 (CLI)
+
+### Problem
+
+Anyone maintaining a repository of skills has no way to catch a broken `SKILL.md` before it
+reaches consumers.
+
+### Proposal
+
+A composite GitHub Action wrapping `agentskills validate`, published so skill repositories can
+gate their PRs:
+
+```yaml
+- uses: pratikxpanda/agentskills-sdk/actions/validate@v1
+  with:
+    path: ./skills
+    fail-on-lint: false
+```
+
+Annotate failures on the offending lines via workflow commands so they surface in the PR diff
+rather than only in the log.
+
+This is the highest-leverage adoption item on the roadmap — it puts the SDK into other
+people's CI, where it gets seen by everyone who opens a PR against those repos.
+
+### Acceptance criteria
+
+- [ ] Action validates a directory of skills and fails the check on invalid input
+- [ ] Failures annotated inline on the PR
+- [ ] `fail-on-lint` toggles whether lint warnings break the build
+- [ ] Documented in the root README with a copy-pasteable snippet
+- [ ] Dogfooded on this repo's own `examples/skills/`
+
+---
+
+## 3. Provider conformance test kit
+
+**Labels:** `theme:correctness`, `type:feature`, `package:testing`
+
+### Problem
+
+`SkillProvider` is an informal contract. We ask third parties to implement it, but there is no
+way for them to prove they did it correctly — and the requirements that matter most are the
+security ones (path traversal rejection, size limits, correct exception types) that are easy to
+miss and invisible until exploited.
+
+### Proposal
+
+A new `agentskills-testing` package publishing a reusable pytest suite:
+
+```python
+from agentskills_testing import ProviderConformanceSuite
+
+class TestMyProvider(ProviderConformanceSuite):
+    @pytest.fixture
+    def provider(self):
+        return MyProvider(...)
+```
+
+The suite asserts the behaviours a provider must exhibit:
+
+- `SkillNotFoundError` for unknown skill IDs
+- `ResourceNotFoundError` for unknown resources
+- Rejection of traversal-style identifiers (`../`, absolute paths, encoded variants)
+- Size limits enforced
+- `get_metadata()` / `get_body()` agree with each other for the same `SKILL.md`
+- Every method is genuinely awaitable and does not block the event loop
+- `list_resources()` behaviour once that lands
+
+Requires a documented fixture contract describing the skill layout a provider under test must
+expose. Run it against the built-in `fs` and `http` providers to prove the suite is real.
+
+### Acceptance criteria
+
+- [ ] Suite published as `agentskills-testing` and importable
+- [ ] Passes against both built-in providers
+- [ ] Deliberately broken provider fixtures fail the expected assertions
+- [ ] Security assertions (traversal, size limits) included and non-skippable
+- [ ] Documented in the custom-provider section of the root README
+
+---
+
+## 4. Test doubles for downstream users
+
+**Labels:** `theme:dx`, `type:feature`, `package:testing`, `good-first-issue`
+
+### Problem
+
+Anyone writing tests for an agent that consumes skills has to hand-roll an `AsyncMock` of
+`SkillProvider` — as this repo's own test suites do, duplicating `_mock_provider` across
+integration packages.
+
+### Proposal
+
+Ship in `agentskills-testing`:
+
+- `InMemorySkillProvider(skills: dict)` — a real, spec-compliant provider backed by a dict, no disk or network.
+- pytest fixtures for a populated registry and a single sample skill.
+- A `build_skill(...)` helper for constructing valid `SKILL.md` content in tests.
+
+Then replace the duplicated `_mock_provider` helpers in this repo's integration tests with it.
+
+### Acceptance criteria
+
+- [ ] `InMemorySkillProvider` passes the conformance suite from item 3
+- [ ] Fixtures documented with examples
+- [ ] This repo's integration tests use it instead of local mocks
+
+---
+
+## 5. Registry-level skill discovery
+
+**Labels:** `theme:dx`, `type:feature`, `package:core`, `package:fs`, `package:http`
+
+### Problem
+
+`registry.register(skill_id, provider)` requires knowing every skill ID up front. Pointing at a
+folder of thirty skills means hard-coding thirty identifiers, and adding a skill means editing
+application code.
+
+### Proposal
+
+Optional `discover()` on `SkillProvider` returning available skill IDs, plus:
+
+```python
+await registry.register_all(provider)
+```
+
+- **Filesystem:** enumerate immediate subdirectories containing a `SKILL.md`.
+- **HTTP:** cannot enumerate a static server. Reuse whatever manifest mechanism the resource-discovery work (v0.3 item 4) settles on.
+- Validation still runs per skill; `register_all` should report every failure rather than aborting on the first.
+
+Same required-vs-optional-method question as v0.3 item 4, and it should be answered the same
+way for both. Settle it once, in one ADR, covering `discover()` and `list_resources()` together.
+
+### Acceptance criteria
+
+- [ ] Decision on the optional-method pattern recorded in an ADR covering both methods
+- [ ] `discover()` on the filesystem provider
+- [ ] `register_all()` on the registry, atomic, reporting all validation failures at once
+- [ ] HTTP behaviour consistent with the resource-discovery manifest
+- [ ] Root README quick-start shows the shorter form
+
+---
+
+## 6. Catalog filtering and token budget
+
+**Labels:** `theme:dx`, `theme:performance`, `type:feature`, `package:core`
+
+### Problem
+
+`get_skills_catalog()` returns every registered skill, and the result is injected into every
+system prompt on every turn. With a large registry the catalog silently becomes a significant
+fixed cost per request, and there is no way to cap or narrow it.
+
+### Proposal
+
+```python
+await registry.get_skills_catalog(
+    format="xml",
+    tags=["incident"],        # filter by frontmatter metadata
+    include=["skill-a"],      # explicit allow-list
+    exclude=["deprecated-x"],
+    max_chars=8000,           # hard ceiling
+)
+```
+
+When `max_chars` would be exceeded, truncate deterministically (stable ordering, whole entries
+only) and append an explicit note that the catalog was truncated — silently dropping skills
+would make agent behaviour non-reproducible.
+
+Depends on tags existing in frontmatter; decide whether to read them from the spec's `metadata`
+dict or propose a dedicated field.
+
+### Acceptance criteria
+
+- [ ] Filtering by tags, include, and exclude
+- [ ] `max_chars` enforced, truncation deterministic and flagged in the output
+- [ ] Existing no-argument behaviour unchanged
+- [ ] Interaction with catalog caching (v0.3 item 1 follow-ups) documented — cache key must include the filter arguments
+
+---
+
+## 7. Skill evaluation harness
+
+**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:testing`, `package:cli`
+
+**Depends on:** item 1 (CLI), item 4 (test doubles)
+
+### Problem
+
+A skill is a prompt, and nobody measures whether a given skill makes an agent better. Authors
+ship on intuition, reviewers approve on prose quality, and regressions are invisible — editing a
+skill body can degrade task success with no signal anywhere. The whole ecosystem currently
+operates on faith.
+
+### Proposal
+
+Test cases alongside the skill, and a runner that measures the difference the skill makes:
+
+```yaml
+# evals/deploy-rollback.yaml
+skill: deploy-rollback
+cases:
+  - prompt: "Production is erroring after the 14:02 deploy. What do I do?"
+    expect:
+      - contains: "kubectl rollout undo"
+      - not_contains: "kubectl delete"
+      - judge: "Recommends rollback before investigating root cause"
+```
+
+`agentskills eval` runs each case twice — once with the skill registered, once without — and
+reports the delta. The paired comparison is the point: absolute pass rates mostly measure the
+underlying model, whereas the difference isolates the skill's contribution.
+
+Assertions in three tiers: deterministic (`contains`, `not_contains`, `regex`), structural (a
+named tool was called), and model-judged for anything subjective. Judged assertions need a
+declared judge model and should report agreement, since an LLM judge is itself unreliable.
+
+### Open questions
+
+- Model access: BYO client via a small protocol, or depend on `litellm` for provider breadth? A protocol keeps `agentskills-testing` dependency-light.
+- Non-determinism: fixed seed and temperature 0 where the provider supports it, plus `n` repeats with a pass threshold rather than a single run.
+- Cost: these hit real APIs. Must be opt-in, never part of the default `pytest` run, and should cache by (skill hash, case hash, model).
+
+### Acceptance criteria
+
+- [ ] Eval case file format documented and validated by `agentskills validate`
+- [ ] `agentskills eval` reports per-case with/without results and an aggregate delta
+- [ ] Deterministic and judged assertions both supported
+- [ ] Results cached by skill and case hash so unchanged cases do not re-bill
+- [ ] Never runs in the default test suite; requires explicit invocation and credentials
+- [ ] Example evals for the skills in `examples/skills/`
+
+---
+
+## 8. Foreign format adapters
+
+**Labels:** `theme:interoperability`, `type:feature`, `package:adapters`
+
+### Problem
+
+The barrier to adopting this SDK is not the API — it is that a team has no skills written. Most
+already have the content, though: `AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/`,
+Claude skill folders, internal runbooks. Asking them to hand-convert all of it before seeing any
+value is a steep first step, and an empty registry is worth nothing.
+
+### Proposal
+
+A new `agentskills-adapters` package converting foreign formats into `Skill` objects at load
+time:
+
+| Source | Mapping |
+|---|---|
+| `AGENTS.md` / `copilot-instructions.md` | Whole file becomes one skill body; name and description derived from the first heading, or synthesised |
+| `.cursor/rules/*.mdc` | One skill per rule file; `description` and `globs` frontmatter map across directly |
+| Claude skill folders | Near-identical structure; largely a validation pass |
+
+This is an **import layer, not a spec fork** — principle 1 holds because nothing new is added to
+the skill format. Adapters produce ordinary `Skill` objects that the registry cannot distinguish
+from native ones.
+
+The honest limitation: formats without a description field lose the catalog entry that
+progressive disclosure depends on, since the agent selects on description. Options are to
+synthesise one, or require the user to supply it. `agentskills init --from <path>` should emit a
+real `SKILL.md` for editing, so adapters are a migration on-ramp rather than a permanent
+dependency.
+
+### Acceptance criteria
+
+- [ ] Adapters for `AGENTS.md`, Copilot instructions, and Cursor rules
+- [ ] Output passes `validate_skill()` and the provider conformance suite
+- [ ] Missing descriptions handled explicitly, never silently blank
+- [ ] `agentskills init --from <path>` converts to a native `SKILL.md`
+- [ ] Documented as a migration path, with its limitations stated
+
+---
+
+## 9. Token cost reporting
+
+**Labels:** `theme:dx`, `type:feature`, `package:cli`, `good-first-issue`
+
+### Problem
+
+Skill authors have no visibility into what their skill costs. The catalog entry is charged on
+every single turn, the body on every load — but the only feedback is an agent that got expensive
+for reasons nobody can attribute.
+
+### Proposal
+
+`agentskills inspect --cost` breaking the skill into what is actually charged and when:
+
+```
+deploy-rollback
+  catalog entry        142 tokens   (every turn)
+  body               3,180 tokens   (on load)
+    ## Overview        410
+    ## Procedure     2,240
+    ## References      530
+  references/api.md  1,890 tokens   (on demand)
+```
+
+Separating per-turn from per-load cost is the part that matters — a bloated description is far
+more expensive than a bloated body, and that is exactly backwards from most authors' intuition.
+
+Use `tiktoken` if available, fall back to a character heuristic with the estimate flagged as
+approximate. Add `--budget` to exit non-zero above a threshold so CI can gate it.
+
+### Acceptance criteria
+
+- [ ] Per-turn and per-load costs reported separately
+- [ ] Body broken down by section
+- [ ] Works without `tiktoken`, marking output as estimated
+- [ ] `--budget` exits non-zero when exceeded
+- [ ] `--format json` for CI consumption
+
+---
+
+## 10. Documentation site
+
+**Labels:** `theme:project-health`, `type:docs`
+
+### Problem
+
+The root README is carrying overview, install, quick start, four integration walkthroughs,
+custom-provider docs, and security notes. It is already too long to skim, and there is no API
+reference anywhere.
+
+### Proposal
+
+MkDocs Material published to GitHub Pages:
+
+- Getting started, concepts (progressive disclosure, providers, registry)
+- One page per package
+- Generated API reference (`mkdocstrings`) from the existing docstrings, which are already thorough
+- The roadmap and ADRs surfaced as site pages
+- Versioned with `mike` so users on an older release get matching docs
+
+Then cut the root README back to overview, install, one quick start, and links.
+
+### Acceptance criteria
+
+- [ ] Site builds in CI and deploys on release
+- [ ] API reference generated from docstrings, not hand-written
+- [ ] Versioned, with a version switcher
+- [ ] Root README reduced accordingly
+
+---
+
+## 11. Architecture decision records
+
+**Labels:** `theme:project-health`, `type:docs`
+
+**Status:** Started — [`docs/adr/`](../adr/) exists with ADR 0001.
+
+### Problem
+
+Cross-package decisions are undocumented, so they get re-litigated or silently reversed. Git
+history shows what changed, not which alternatives were rejected and why.
+
+### Proposal
+
+Backfill ADRs for decisions already made:
+
+| Decision | Why it needs a record |
+|---|---|
+| Fully async provider interface | Constrains every provider implementation; the fs provider is currently sync-under-async because of it |
+| Six packages instead of one with extras | Shapes install UX, release process, and version coordination |
+| Exception taxonomy | About to be extended by v0.3 item 7; the rationale should exist first |
+| Optional-method pattern for provider capabilities | Blocks v0.3 item 4 and v0.4 item 5 — write this one **before** implementing either |
+| Binary resources as a JSON envelope | Chosen for consistency across integrations over MCP-native content blocks; decide before v0.3 item 5 is implemented |
+
+Add a short `docs/adr/README.md` with the template and the numbering convention.
+
+### Acceptance criteria
+
+- [ ] ADR template and index in place
+- [ ] The optional-method-pattern ADR written before v0.3 item 4 starts
+- [ ] Remaining backfill ADRs written
+- [ ] Contributing guide points at ADRs for design-affecting changes

--- a/docs/issues/v0.5.md
+++ b/docs/issues/v0.5.md
@@ -1,0 +1,75 @@
+# v0.5 "Agent Effectiveness"
+
+Specifications for the v0.5 roadmap items, in the same order as the table in the
+[roadmap](../ROADMAP.md). Milestone: `v0.5`.
+
+The other v0.5 items (semantic skill selection, section-level disclosure, vision-native assets,
+selection metadata, single-skill fast path) still need design work before they can be specified
+here. The one below is scoped enough to act on, and is item 3 in the roadmap table.
+
+---
+
+## 3. Session-aware progressive disclosure in the context provider
+
+**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:agentframework`
+
+### Problem
+
+`AgentSkillsContextProvider.before_run()` re-injects the full catalog, the full usage
+instructions, and all five tools on **every** `agent.run()` call, regardless of what the agent
+already loaded. In a long session that is repeated token spend on information the model already
+has, plus repeated provider I/O.
+
+Agent Framework's `BaseContextProvider` gives us `before_run` / `after_run` hooks, a
+provider-scoped `state` dict that persists across runs within a session, a shared
+`session.state`, and a per-invocation `SessionContext` (`input_messages`, `instructions`,
+`tools`, `response`, `metadata`, `options`).
+
+### Proposal
+
+Ordered by value; each could ship independently.
+
+**a. Cache the built prompt in `state`.** Store the assembled catalog and instructions after the
+first `before_run()`; skip provider I/O on subsequent runs. Optional `cache_ttl`. Biggest win
+for HTTP-backed registries and the cheapest to implement.
+
+**b. Track loaded skills.** In `after_run()`, inspect `context.response` for skill tool calls
+and record IDs in `state["loaded_skills"]`. Skip re-injecting content the agent already pulled.
+
+**c. Conditional tool injection.** First turn: inject only `get_skill_metadata` and
+`get_skill_body`. Once a skill body has been loaded, add `get_skill_reference` /
+`get_skill_script` / `get_skill_asset` for that skill. Framework-level progressive disclosure
+instead of a prompt instruction, and a smaller tool surface for the model to reason about.
+
+**d. Catalog pruning.** Inspect `context.input_messages` for topic signal and advertise only
+relevant skills, falling back to the full catalog when the topic is unclear. Highest risk — a
+wrong prune hides a skill the agent needed. Should be opt-in and evaluated before it becomes a
+default.
+
+**e. Usage telemetry via `after_run`.** Count skill and resource usage into `state`, and expose
+a callback so hosts can export it. Answers "which skills are actually used" and feeds Hub
+analytics.
+
+**f. Cross-provider signalling.** Publish `metadata["agentskills_loaded_skills"]` on
+`context.metadata` so other context providers can adapt; optionally read another provider's
+topic classification to inform (d).
+
+**g. Context messages instead of instructions.** Use `context.extend_messages()` so injected
+skill content carries source attribution and can be filtered by other providers via
+`context.get_messages(sources={"agentskills"})`.
+
+**h. Agent-aware formatting.** Use the `agent` handle to pick catalog format by model family
+(XML for Claude, markdown elsewhere) rather than a fixed constructor argument.
+
+### Notes
+
+- (a) and (b) are the core of the issue; (d) needs an evaluation harness before it can be trusted.
+- Anything here that generalises beyond Agent Framework should land in `agentskills-core` so the LangChain and MCP paths benefit too.
+- API reference: [`_sessions.py`](https://github.com/microsoft/agent-framework/blob/e8a7ffbc14fbac54dbbeeaaaf94d78094526ad22/python/packages/core/agent_framework/_sessions.py#L272)
+
+### Acceptance criteria
+
+- [ ] Prompt/catalog cached across runs within a session, with opt-out
+- [ ] Loaded skills tracked in provider-scoped `state`
+- [ ] Repeated `before_run()` calls remain idempotent
+- [ ] Token count for turn N+1 measurably lower than today for a multi-turn session

--- a/packages/integrations/agentskills-agentframework/README.md
+++ b/packages/integrations/agentskills-agentframework/README.md
@@ -119,6 +119,21 @@ Returns a list of Agent Framework function tools bound to the given registry.
 
 Returns a markdown string explaining the progressive-disclosure workflow - read metadata, then body, then fetch resources on demand. Designed for system-prompt injection alongside the skill catalog.
 
+## Comparison with Agent Framework's built-in provider
+
+Agent Framework ships its own `FileAgentSkillsProvider`. Both plug into the same lifecycle, but they solve different problems:
+
+| | `FileAgentSkillsProvider` (built-in) | `AgentSkillsContextProvider` (this package) |
+| --- | --- | --- |
+| **Backends** | Filesystem only | Any `SkillProvider` - filesystem, HTTP, custom |
+| **Tool surface** | 2 generic tools (`load_skill`, `read_skill_resource`) | 5 typed tools (metadata, body, reference, script, asset) |
+| **Resource semantics** | Flat - all resources accessed by path | Typed - the agent knows the category of what it is reading |
+| **Discovery / parsing** | Built into the framework | Delegated to `agentskills-core` |
+| **Composability** | Single provider | Mix multiple providers in one registry |
+| **Setup** | Point at a folder | Register skills explicitly |
+
+If all you need is skills in a local folder, the built-in provider is already installed and is the simpler choice. Reach for this package when skills come from somewhere other than disk, when you need several sources in one catalog, or when you want the agent to distinguish a script from a reference document.
+
 ## Example
 
 See [examples/agent-framework/](../../../examples/agent-framework/) for full working demos.


### PR DESCRIPTION
Replace the gitignored docs/backlog/ folder with planning artifacts that live in the repository and are reviewable.

- docs/ROADMAP.md: product principles, themes, milestones v0.3-v1.0, and explicit non-goals. Adds Agent effectiveness and Interoperability themes alongside the correctness and hardening work.
- docs/issues/: durable specifications behind each roadmap item, one file per milestone, kept whether or not the item has been filed on GitHub.
- docs/adr/0001: records why the MCP context provider ships in agentskills-mcp-server behind an extra.

Preserves content from the retired backlog: the built-in provider comparison moves into the agentskills-agentframework README, and the remaining items become roadmap entries and issue specs.