### PR TITLE
perf: cache skill content, build catalogs concurrently, unblock the event loop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,68 @@
+# Working in this repository
+
+Poetry monorepo. Six packages, versioned and released together.
+
+| Path | Package |
+| --- | --- |
+| `packages/core/agentskills-core` | Registry, `SkillProvider` ABC, spec validation. Only dependency is `pyyaml`. |
+| `packages/providers/agentskills-fs` | Local filesystem provider |
+| `packages/providers/agentskills-http` | Static HTTP / CDN provider |
+| `packages/integrations/agentskills-langchain` | LangChain tools |
+| `packages/integrations/agentskills-agentframework` | Microsoft Agent Framework context provider |
+| `packages/integrations/agentskills-mcp-server` | MCP server + Agent Framework MCP bridge |
+
+Planning lives in `docs/ROADMAP.md`, per-milestone specs in `docs/issues/`, settled
+decisions in `docs/adr/`.
+
+## Branch workflow
+
+Never commit to `main`. For every unit of work:
+
+```bash
+git checkout main
+git pull --prune
+git checkout -b <type>/<slug>      # fix/ feat/ perf/ docs/ chore/
+# implement, test, lint
+git push -u origin <branch>
+```
+
+The maintainer merges pull requests manually. **Do not create, update, or comment on
+issues or pull requests, and do not use the `gh` CLI for that.** After a merge, sync
+`main` and cut a fresh branch for the next item.
+
+One roadmap item — or one tightly coupled cluster — per branch. If scope drifts, rename
+the branch or squash-merge under a title that matches what actually landed.
+
+## Commands
+
+```bash
+poetry install                                    # after any pyproject change, run poetry lock first
+python -m pytest packages -q --no-header          # baseline: 327 passed, 1 skipped
+python -m ruff check packages
+python -m ruff format --check packages
+```
+
+`scripts/dev.py check` also runs a `mypy` step, but `mypy` is not currently installed —
+that task fails for reasons unrelated to your change.
+
+## Conventions
+
+- Type hints on all public functions; Google-style docstrings on public APIs.
+- Every package ships `py.typed`; keep the marker intact.
+- Comments explain what the code cannot show on its own. One line, not a paragraph.
+- Package READMEs are used verbatim as the PyPI `long_description`, so **every relative
+  link in them is broken on PyPI**. Use absolute `https://github.com/...` URLs.
+
+## Traps worth knowing
+
+- **`poetry.lock` hides upstream breaking changes.** Locked installs kept CI green while
+  the published packages were broken for every new user. The advisory `test-unlocked` CI
+  job resolves without the lock; when it fails, the fix belongs in a version constraint,
+  not in the job.
+- **Dependency ceilings need evidence.** Check the dependency's real `requires_python` and
+  classifiers on PyPI before adding or trusting an upper bound.
+- **A 200 response does not mean a badge rendered.** shields.io returns 200 with the words
+  "rate limited by upstream service" drawn into the SVG. Inspect the rendered text.
+- **Resolve markdown links programmatically** rather than counting `../` by eye.
+- **PowerShell has no heredoc.** Use repeated `-m` flags for commit messages; embedded
+  `` `n `` desynchronises the shell.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,9 +48,9 @@ Close the highest-severity correctness and performance gaps before the API surfa
 
 | Item | Theme | Package(s) | Notes |
 |---|---|---|---|
-| Provider content caching | Performance | `agentskills-fs`, `agentskills-http` | A single skill's `SKILL.md` is fetched up to 5x per session — twice during registration (`validate_skill()` calls `get_body()` and `get_metadata()` independently), once per catalog build, and again on each tool call. For HTTP that is 5 network round-trips for one immutable file. Cache per provider instance; use `ETag` / `Last-Modified` conditional requests rather than a blind TTL. |
-| Concurrent catalog build | Performance | `agentskills-core` | `get_skills_catalog()` fetches metadata serially. Fan out with `asyncio.gather` and bounded concurrency. |
-| Non-blocking filesystem I/O | Performance | `agentskills-fs` | The provider is `async` but reads synchronously, blocking the event loop. Move to a thread executor. |
+| Provider content caching | Performance | `agentskills-fs`, `agentskills-http` | **Implemented, awaiting release.** A single skill's `SKILL.md` was fetched up to 5x per session — twice during registration (`validate_skill()` calls `get_body()` and `get_metadata()` independently), once per catalog build, and again on each tool call. Now cached per provider instance with an explicit `invalidate()`. HTTP revalidation via `ETag` / `Last-Modified` is opt-in (`revalidate=True`) rather than default, since a conditional request per access defeats the point for the common static-host case. |
+| Concurrent catalog build | Performance | `agentskills-core` | **Implemented, awaiting release.** `get_skills_catalog()` fetched metadata serially. Now fans out with `asyncio.gather` under a bounded semaphore (`SkillRegistry(catalog_concurrency=8)`); output ordering is unchanged. |
+| Non-blocking filesystem I/O | Performance | `agentskills-fs` | **Implemented, awaiting release.** The provider was `async` but read synchronously, blocking the event loop. Path resolution, stat and read now run in a worker thread via `asyncio.to_thread`. |
 | Resource discovery API | Correctness | `agentskills-core` + providers | No way for an agent to learn which references/scripts/assets exist. Add `list_resources(skill_id)` returning names by kind. Today discovery depends on SKILL.md prose. |
 | Binary-safe resources | Correctness | `agentskills-core` + all integrations | All three integrations decode provider bytes with `.decode("utf-8", errors="replace")`, silently destroying images, PDFs, and archives. Detect binary content and return a structured envelope instead; use MCP's native binary content blocks where the protocol supports them. |
 | Optional `version` frontmatter | Correctness | `agentskills-core` | Semver, validated when present, surfaced in `get_metadata()`. Prerequisite for Hub version pinning and for any dependency/compatibility story. |
@@ -58,7 +58,7 @@ Close the highest-severity correctness and performance gaps before the API surfa
 | Structured logging | Operability | all | Consistent `agentskills.*` logger namespace, no handlers attached by the library, never log secrets or URLs containing credentials. |
 | Coverage gate in CI | Project health | repo | `pytest-cov` with a floor, enforced in CI, badge in README. |
 | Automated PyPI publish | Project health | repo | Replace manual `publish.ps1` runs with GitHub Actions **Trusted Publishing** (OIDC, no long-lived tokens), triggered by the release tag. |
-| Agent Framework 1.x API rename | Correctness | `agentskills-agentframework`, `agentskills-mcp-server` | **Ships broken today.** `agent-framework-core` 1.12.1 renamed `BaseContextProvider` to `ContextProvider`; our constraint `>=1.0.0rc3,<2.0` admits it, so a fresh install raises `ImportError` on import. Masked locally because `poetry.lock` pins 1.0.0rc3. |
+| Agent Framework 1.x API rename | Correctness | `agentskills-agentframework`, `agentskills-mcp-server` | **Merged, awaiting release.** `agent-framework-core` 1.12.1 renamed `BaseContextProvider` to `ContextProvider`; our constraint `>=1.0.0rc3,<2.0` admitted it, so a fresh install raised `ImportError` on import. Masked locally because `poetry.lock` pinned 1.0.0rc3. Floor raised to `>=1.0`. |
 | Python 3.14 support | Project health | all | **Merged, awaiting release.** Every package capped `python` at `<3.14`, so installs failed on current stable Python. Ceiling raised to `<4.0`; no dependency justified the old cap. |
 
 ---
@@ -143,7 +143,6 @@ Breadth, once the core contracts are stable enough that each new package is chea
 |---|---|
 | API freeze | Public surface documented and frozen; anything not documented is explicitly private. |
 | Compatibility policy | SemVer commitments, a written deprecation policy with a minimum support window, and coordinated cross-package version guarantees. |
-| Python 3.14 support | Currently blocked on upstream dependencies. Track with a nightly allow-failure CI matrix entry so we know the day it unblocks. |
 | Release automation end-to-end | Changelog generation, signed artifacts with build provenance/attestations, automated publish on tag. |
 | Hub interoperability | The SDK contracts the Hub depends on (versioning, integrity, telemetry, MCP gateway composition) are stable and documented. |
 

--- a/docs/issues/v0.3.md
+++ b/docs/issues/v0.3.md
@@ -51,12 +51,27 @@ keeps long-lived servers correct when a skill is republished. Expose an explicit
 
 ### Acceptance criteria
 
-- [ ] HTTP provider issues exactly one request per skill across a full register → catalog → tool-call flow (assert on mocked `httpx` call count)
-- [ ] Filesystem provider reads each `SKILL.md` once (spy on `Path.read_text`)
-- [ ] Cache is per-instance — two providers do not share state
-- [ ] `invalidate()` clears one skill or all
-- [ ] HTTP revalidates with `ETag`/`Last-Modified` and handles `304`
-- [ ] Existing tests pass unchanged
+- [x] HTTP provider issues exactly one request per skill across a full register → catalog → tool-call flow (assert on mocked `httpx` call count)
+- [x] Filesystem provider reads each `SKILL.md` once (spy on `Path.read_text`)
+- [x] Cache is per-instance — two providers do not share state
+- [x] `invalidate()` clears one skill or all
+- [x] HTTP revalidates with `ETag`/`Last-Modified` and handles `304`
+- [x] Existing tests pass unchanged
+
+### Implementation notes
+
+**Status: implemented, awaiting release.**
+
+Two acceptance criteria conflict: "exactly one request per skill" and "revalidates with
+`ETag`/`Last-Modified`" cannot both hold under one default, because revalidation costs a
+round-trip per access even when it returns `304`. Resolved by making revalidation opt-in:
+`HTTPStaticFileSkillProvider(..., revalidate=True)`. The default serves cached content until
+`invalidate()` is called, which is right for the common case (a static host, a process that
+outlives a few agent turns). Long-lived servers fronting a mutable host should opt in.
+
+Only `SKILL.md` is cached. Scripts, assets and references are left uncached: they are larger,
+typically read once, and caching them would make the provider's memory footprint depend on
+untrusted content size.
 
 ### Related follow-ups (file separately if wanted)
 
@@ -84,10 +99,25 @@ order.
 
 ### Acceptance criteria
 
-- [ ] Catalog output is byte-identical to the serial implementation for the same registry
-- [ ] Metadata fetches run concurrently (assert with an instrumented provider)
-- [ ] Concurrency is bounded and configurable
-- [ ] A failure in one skill's metadata surfaces with the offending `skill_id` in the message
+- [x] Catalog output is byte-identical to the serial implementation for the same registry
+- [x] Metadata fetches run concurrently (assert with an instrumented provider)
+- [x] Concurrency is bounded and configurable
+- [x] A failure in one skill's metadata surfaces with the offending `skill_id` in the message
+
+### Implementation notes
+
+**Status: implemented, awaiting release.**
+
+Concurrency is bounded by an `asyncio.Semaphore` and configured per registry:
+`SkillRegistry(catalog_concurrency=8)`. Values below 1 raise `ValueError`.
+
+Ordering is preserved by zipping the `asyncio.gather` results back against `list_skills()`
+rather than sorting afterwards — `gather` already returns results in argument order, so no
+sort is needed and the catalog stays byte-identical to the serial version.
+
+Skill ID context is attached with `exc.add_note()` (PEP 678) rather than by wrapping in a new
+exception. Wrapping would have changed the exception *type* callers see, breaking anyone
+catching `SkillNotFoundError` from a catalog build.
 
 ---
 
@@ -109,9 +139,23 @@ rejected without loading them.
 
 ### Acceptance criteria
 
-- [ ] No blocking filesystem calls on the event loop
-- [ ] Size limit still enforced
-- [ ] Concurrent reads from one provider work correctly
+- [x] No blocking filesystem calls on the event loop
+- [x] Size limit still enforced
+- [x] Concurrent reads from one provider work correctly
+
+### Implementation notes
+
+**Status: implemented, awaiting release.**
+
+Used `asyncio.to_thread` rather than `anyio.to_thread.run_sync`. Loop-agnosticism was not
+worth a new runtime dependency on a provider package whose only current dependency is
+`agentskills-core`; the rest of the SDK is asyncio-based already. Revisit if anyone asks for
+Trio support.
+
+The *whole* helper moved to the worker thread, not just the `read_text()` call. The
+path-traversal guard (`Path.resolve()`, `is_dir()`, `is_file()`, `stat()`) issues syscalls
+too, and on a cold cache or a network mount those dominate. Moving only the read would have
+left most of the blocking behind.
 
 ---
 

--- a/packages/core/agentskills-core/README.md
+++ b/packages/core/agentskills-core/README.md
@@ -70,6 +70,12 @@ xml_catalog = await registry.get_skills_catalog(format="xml")       # <available
 md_catalog = await registry.get_skills_catalog(format="markdown")   # Markdown list
 ```
 
+Metadata for every registered skill is fetched concurrently, which matters when providers are network-backed. Bound the fan-out at construction time:
+
+```python
+registry = SkillRegistry(catalog_concurrency=4)   # default: 8
+```
+
 ### Implementing a Custom Provider
 
 ```python

--- a/packages/core/agentskills-core/agentskills_core/registry.py
+++ b/packages/core/agentskills-core/agentskills_core/registry.py
@@ -22,13 +22,17 @@ Example::
 
 from __future__ import annotations
 
-from typing import Literal, overload
+import asyncio
+from typing import Any, Literal, overload
 from xml.etree.ElementTree import Element, SubElement, indent, tostring
 
 from agentskills_core.exceptions import SkillNotFoundError
 from agentskills_core.provider import SkillProvider
 from agentskills_core.skill import Skill
 from agentskills_core.validation import validate_skill
+
+#: Metadata fetches issued in parallel when building a catalog.
+DEFAULT_CATALOG_CONCURRENCY = 8
 
 
 class SkillRegistry:
@@ -48,8 +52,20 @@ class SkillRegistry:
     providers.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, catalog_concurrency: int = DEFAULT_CATALOG_CONCURRENCY) -> None:
+        """Create an empty registry.
+
+        Args:
+            catalog_concurrency: Maximum number of provider metadata
+                fetches issued in parallel by :meth:`get_skills_catalog`.
+
+        Raises:
+            ValueError: If *catalog_concurrency* is less than 1.
+        """
+        if catalog_concurrency < 1:
+            raise ValueError("catalog_concurrency must be at least 1")
         self._skills: dict[str, Skill] = {}
+        self._catalog_concurrency = catalog_concurrency
 
     def __repr__(self) -> str:
         n = len(self._skills)
@@ -220,15 +236,34 @@ class SkillRegistry:
     # Private helpers
     # ------------------------------------------------------------------
 
+    async def _gather_metadata(self) -> list[tuple[Skill, dict[str, Any]]]:
+        """Fetch metadata for every registered skill concurrently.
+
+        Ordering follows :meth:`list_skills` regardless of completion
+        order, so catalog output is deterministic.
+        """
+        skills = self.list_skills()
+        semaphore = asyncio.Semaphore(self._catalog_concurrency)
+
+        async def fetch(skill: Skill) -> dict[str, Any]:
+            async with semaphore:
+                try:
+                    return await skill.get_metadata()
+                except Exception as exc:
+                    exc.add_note(f"raised while building the catalog entry for '{skill.get_id()}'")
+                    raise
+
+        metadata = await asyncio.gather(*(fetch(skill) for skill in skills))
+        return list(zip(skills, metadata, strict=True))
+
     async def _build_xml(self) -> str:
         """Return an ``<available_skills>`` XML block."""
-        skills = self.list_skills()
-        if not skills:
+        entries = await self._gather_metadata()
+        if not entries:
             return "<available_skills />"
 
         root = Element("available_skills")
-        for skill in skills:
-            meta = await skill.get_metadata()
+        for skill, meta in entries:
             skill_el = SubElement(root, "skill")
             name_el = SubElement(skill_el, "name")
             name_el.text = meta.get("name", skill.get_id())
@@ -239,8 +274,8 @@ class SkillRegistry:
 
     async def _build_markdown(self) -> str:
         """Return a Markdown-formatted skill catalog."""
-        skills = self.list_skills()
-        if not skills:
+        entries = await self._gather_metadata()
+        if not entries:
             return "No skills are currently available."
 
         lines: list[str] = [
@@ -248,9 +283,7 @@ class SkillRegistry:
             "",
         ]
 
-        for skill in skills:
-            meta = await skill.get_metadata()
-
+        for skill, meta in entries:
             name = meta.get("name", skill.get_id())
             description = meta.get("description", "No description available.")
 

--- a/packages/providers/agentskills-fs/README.md
+++ b/packages/providers/agentskills-fs/README.md
@@ -46,7 +46,14 @@ body = await skill.get_body()
 script = await skill.get_script("page-oncall.sh")
 ```
 
-The provider reads files synchronously (local disk I/O is fast for small skill files) but exposes an `async` interface to satisfy the `SkillProvider` contract.
+Blocking file I/O runs in a worker thread, so a slow or networked filesystem does not stall other coroutines.
+
+`SKILL.md` content is cached per provider instance after the first read — a single skill is otherwise re-read up to five times in one agent session. Call `invalidate()` when skills change on disk.
+
+```python
+provider.invalidate("incident-response")  # forget one skill
+provider.invalidate()                      # forget everything
+```
 
 ## Security
 
@@ -72,6 +79,7 @@ For the full security policy, see [SECURITY.md](https://github.com/pratikxpanda/
 | `get_script(skill_id, name)` | `bytes` | Raw content of a script file |
 | `get_asset(skill_id, name)` | `bytes` | Raw content of an asset file |
 | `get_reference(skill_id, name)` | `bytes` | Raw content of a reference file |
+| `invalidate(skill_id=None)` | `None` | Drop cached `SKILL.md` content for one skill, or all skills |
 
 ## License
 

--- a/packages/providers/agentskills-fs/agentskills_fs/local.py
+++ b/packages/providers/agentskills-fs/agentskills_fs/local.py
@@ -13,12 +13,14 @@ discover skills.  Registration is handled explicitly by the application
 via :meth:`SkillRegistry.register <agentskills_core.SkillRegistry.register>`.
 
 All methods are ``async`` to satisfy the :class:`~agentskills_core.SkillProvider`
-interface.  File I/O is synchronous internally because skill files are
-small and local disk reads do not meaningfully block the event loop.
+interface.  Blocking file I/O runs in a worker thread via
+:func:`asyncio.to_thread`, so concurrent agent sessions are not stalled by
+disk latency.
 """
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -69,6 +71,11 @@ class LocalFileSystemSkillProvider(SkillProvider):
             :class:`~agentskills_core.AgentSkillsError`.  Defaults
             to 10 MB.
 
+    ``SKILL.md`` contents are cached per provider instance after the
+    first read, because a single skill is otherwise re-read up to five
+    times in one agent session.  Call :meth:`invalidate` when skills
+    change on disk.
+
     Raises:
         NotADirectoryError: If *root* does not exist or is not a
             directory.
@@ -89,6 +96,19 @@ class LocalFileSystemSkillProvider(SkillProvider):
         if not self._root.is_dir():
             raise NotADirectoryError(f"Skill root does not exist: {self._root}")
         self._max_file_bytes = max_file_bytes
+        self._skill_md_cache: dict[str, str] = {}
+
+    def invalidate(self, skill_id: str | None = None) -> None:
+        """Drop cached ``SKILL.md`` content.
+
+        Args:
+            skill_id: Skill to forget.  Clears the whole cache when
+                omitted.  Unknown IDs are ignored.
+        """
+        if skill_id is None:
+            self._skill_md_cache.clear()
+        else:
+            self._skill_md_cache.pop(skill_id, None)
 
     # ------------------------------------------------------------------
     # Metadata & body — parsed lazily from SKILL.md
@@ -111,7 +131,7 @@ class LocalFileSystemSkillProvider(SkillProvider):
             SkillNotFoundError: If the skill directory or ``SKILL.md``
                 does not exist.
         """
-        raw = self._read_skill_md(skill_id)
+        raw = await self._read_skill_md(skill_id)
         frontmatter, _ = split_frontmatter(raw)
         return frontmatter
 
@@ -128,7 +148,7 @@ class LocalFileSystemSkillProvider(SkillProvider):
             SkillNotFoundError: If the skill directory or ``SKILL.md``
                 does not exist.
         """
-        raw = self._read_skill_md(skill_id)
+        raw = await self._read_skill_md(skill_id)
         _, body = split_frontmatter(raw)
         return body
 
@@ -149,7 +169,7 @@ class LocalFileSystemSkillProvider(SkillProvider):
         Raises:
             ResourceNotFoundError: If the file does not exist.
         """
-        return self._read_subdir_file(skill_id, "scripts", name)
+        return await self._read_subdir_file(skill_id, "scripts", name)
 
     # ------------------------------------------------------------------
     # Assets
@@ -168,7 +188,7 @@ class LocalFileSystemSkillProvider(SkillProvider):
         Raises:
             ResourceNotFoundError: If the file does not exist.
         """
-        return self._read_subdir_file(skill_id, "assets", name)
+        return await self._read_subdir_file(skill_id, "assets", name)
 
     # ------------------------------------------------------------------
     # References
@@ -187,7 +207,7 @@ class LocalFileSystemSkillProvider(SkillProvider):
         Raises:
             ResourceNotFoundError: If the file does not exist.
         """
-        return self._read_subdir_file(skill_id, "references", name)
+        return await self._read_subdir_file(skill_id, "references", name)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -212,7 +232,16 @@ class LocalFileSystemSkillProvider(SkillProvider):
             raise SkillNotFoundError(f"Skill not found: {skill_id!r}")
         return path
 
-    def _read_skill_md(self, skill_id: str) -> str:
+    async def _read_skill_md(self, skill_id: str) -> str:
+        """Read a skill's ``SKILL.md`` without blocking the event loop."""
+        cached = self._skill_md_cache.get(skill_id)
+        if cached is not None:
+            return cached
+        text = await asyncio.to_thread(self._read_skill_md_sync, skill_id)
+        self._skill_md_cache[skill_id] = text
+        return text
+
+    def _read_skill_md_sync(self, skill_id: str) -> str:
         """Read the full text of a skill's ``SKILL.md`` file.
 
         Args:
@@ -235,7 +264,11 @@ class LocalFileSystemSkillProvider(SkillProvider):
             )
         return skill_md.read_text(encoding="utf-8")
 
-    def _read_subdir_file(self, skill_id: str, subdir: str, name: str) -> bytes:
+    async def _read_subdir_file(self, skill_id: str, subdir: str, name: str) -> bytes:
+        """Read a skill resource without blocking the event loop."""
+        return await asyncio.to_thread(self._read_subdir_file_sync, skill_id, subdir, name)
+
+    def _read_subdir_file_sync(self, skill_id: str, subdir: str, name: str) -> bytes:
         """Read a single file from a skill's subdirectory.
 
         Args:

--- a/packages/providers/agentskills-fs/tests/test_local.py
+++ b/packages/providers/agentskills-fs/tests/test_local.py
@@ -295,3 +295,123 @@ class TestSecurityFSBoundary:
         provider = LocalFileSystemSkillProvider(tmp_path / "root")
         with pytest.raises(SkillNotFoundError):
             await provider.get_metadata("evil")
+
+
+class TestSkillMdCaching:
+    async def test_skill_md_read_once(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Repeated accesses hit the disk exactly once."""
+        _create_skill(tmp_path)
+        reads: list[Path] = []
+        original = Path.read_text
+
+        def counting_read_text(self: Path, *args: object, **kwargs: object) -> str:
+            reads.append(self)
+            return original(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+        provider = LocalFileSystemSkillProvider(tmp_path)
+        await provider.get_metadata("test-skill")
+        await provider.get_body("test-skill")
+        await provider.get_metadata("test-skill")
+
+        assert [p.name for p in reads] == ["SKILL.md"]
+
+    async def test_cache_is_per_instance(self, tmp_path: Path):
+        """One provider's cache does not serve another provider."""
+        _create_skill(tmp_path)
+        first = LocalFileSystemSkillProvider(tmp_path)
+        await first.get_body("test-skill")
+
+        (tmp_path / "test-skill" / "SKILL.md").write_text(
+            SAMPLE_SKILL_MD.replace("body of the test skill", "updated body"),
+            encoding="utf-8",
+        )
+
+        second = LocalFileSystemSkillProvider(tmp_path)
+        assert "updated body" in await second.get_body("test-skill")
+        assert "updated body" not in await first.get_body("test-skill")
+
+    async def test_invalidate_single_skill(self, tmp_path: Path):
+        _create_skill(tmp_path, skill_id="a")
+        _create_skill(tmp_path, skill_id="b")
+        provider = LocalFileSystemSkillProvider(tmp_path)
+        await provider.get_body("a")
+        await provider.get_body("b")
+
+        for skill_id in ("a", "b"):
+            (tmp_path / skill_id / "SKILL.md").write_text(
+                SAMPLE_SKILL_MD.replace("body of the test skill", "updated body"),
+                encoding="utf-8",
+            )
+
+        provider.invalidate("a")
+        assert "updated body" in await provider.get_body("a")
+        assert "updated body" not in await provider.get_body("b")
+
+    async def test_invalidate_all(self, tmp_path: Path):
+        _create_skill(tmp_path)
+        provider = LocalFileSystemSkillProvider(tmp_path)
+        await provider.get_body("test-skill")
+
+        (tmp_path / "test-skill" / "SKILL.md").write_text(
+            SAMPLE_SKILL_MD.replace("body of the test skill", "updated body"),
+            encoding="utf-8",
+        )
+
+        provider.invalidate()
+        assert "updated body" in await provider.get_body("test-skill")
+
+    async def test_invalidate_unknown_skill_is_noop(self, tmp_path: Path):
+        provider = LocalFileSystemSkillProvider(tmp_path)
+        provider.invalidate("never-registered")
+
+    async def test_concurrent_reads(self, tmp_path: Path):
+        """Concurrent reads across skills return the right content."""
+        import asyncio
+
+        for skill_id in ("a", "b", "c"):
+            _create_skill(
+                tmp_path,
+                skill_id=skill_id,
+                skill_md=SAMPLE_SKILL_MD.replace("test skill.", f"skill {skill_id}."),
+            )
+
+        provider = LocalFileSystemSkillProvider(tmp_path)
+        results = await asyncio.gather(
+            *(provider.get_metadata(skill_id) for skill_id in ("a", "b", "c") for _ in range(4))
+        )
+
+        assert len(results) == 12
+        descriptions = {r["description"] for r in results}
+        assert descriptions == {
+            "A test skill for unit testing.".replace("test skill.", f"skill {s}.") for s in "abc"
+        }
+
+    async def test_does_not_block_the_event_loop(self, tmp_path: Path):
+        """A slow read must not stall other coroutines."""
+        import asyncio
+        import time
+
+        _create_skill(tmp_path)
+        provider = LocalFileSystemSkillProvider(tmp_path)
+        original = provider._read_skill_md_sync
+        ticks = 0
+
+        def slow_read(skill_id: str) -> str:
+            time.sleep(0.2)
+            return original(skill_id)
+
+        provider._read_skill_md_sync = slow_read  # type: ignore[method-assign]
+
+        async def tick() -> None:
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        ticker = asyncio.create_task(tick())
+        await provider.get_body("test-skill")
+        ticker.cancel()
+
+        assert ticks > 1

--- a/packages/providers/agentskills-http/README.md
+++ b/packages/providers/agentskills-http/README.md
@@ -74,7 +74,7 @@ provider = HTTPStaticFileSkillProvider("https://cdn.example.com/skills", client=
 
 ## API
 
-### `HTTPStaticFileSkillProvider(base_url, *, client=None, headers=None, params=None, require_tls=False, max_response_bytes=10_485_760)`
+### `HTTPStaticFileSkillProvider(base_url, *, client=None, headers=None, params=None, require_tls=False, max_response_bytes=10_485_760, revalidate=False)`
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -84,6 +84,7 @@ provider = HTTPStaticFileSkillProvider("https://cdn.example.com/skills", client=
 | `params` | `dict \| None` | `None` | Query parameters appended to every request |
 | `require_tls` | `bool` | `False` | Reject `http://` URLs with `ValueError` |
 | `max_response_bytes` | `int` | `10_485_760` | Maximum allowed response size in bytes |
+| `revalidate` | `bool` | `False` | Re-check cached `SKILL.md` on every access with `If-None-Match` / `If-Modified-Since` |
 
 > **Note:** `client` and `headers`/`params` are mutually exclusive. Configure headers and params on the client directly when providing your own.
 
@@ -94,9 +95,22 @@ provider = HTTPStaticFileSkillProvider("https://cdn.example.com/skills", client=
 | `get_script(skill_id, name)` | `bytes` | Raw script content |
 | `get_asset(skill_id, name)` | `bytes` | Raw asset content |
 | `get_reference(skill_id, name)` | `bytes` | Raw reference content |
+| `invalidate(skill_id=None)` | `None` | Drop cached `SKILL.md` content for one skill, or all skills |
 | `aclose()` | `None` | Close the HTTP client (if owned by the provider) |
 
 Supports `async with` for automatic cleanup.
+
+## Caching
+
+`SKILL.md` responses are cached per provider instance. Without it a single skill costs up to five round-trips per agent session — twice during registration, once per catalog build, and again on each tool call. Scripts, assets and references are not cached.
+
+By default the cache is served until you call `invalidate()`. If your host serves mutable skills and the process is long-lived, opt into conditional revalidation instead:
+
+```python
+provider = HTTPStaticFileSkillProvider(BASE, revalidate=True)
+```
+
+That sends `If-None-Match` / `If-Modified-Since` on every access and reuses the cached body on `304`. It costs one cheap round-trip per access, so prefer the default plus an explicit `invalidate()` when you control publishing.
 
 ## Error Handling
 

--- a/packages/providers/agentskills-http/agentskills_http/static.py
+++ b/packages/providers/agentskills-http/agentskills_http/static.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import re
 import warnings
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote, urlparse
 
@@ -54,6 +55,15 @@ DEFAULT_MAX_RESPONSE_BYTES: int = 10 * 1024 * 1024
 
 #: Default HTTP request timeout in seconds.
 DEFAULT_TIMEOUT_SECONDS: float = 30.0
+
+
+@dataclass(frozen=True)
+class _CachedSkillMd:
+    """A fetched ``SKILL.md`` plus the validators needed to revalidate it."""
+
+    text: str
+    etag: str | None
+    last_modified: str | None
 
 
 class HTTPStaticFileSkillProvider(SkillProvider):
@@ -88,6 +98,17 @@ class HTTPStaticFileSkillProvider(SkillProvider):
             Responses exceeding this limit raise
             :class:`~agentskills_core.AgentSkillsError`.  Defaults to
             10 MB.
+        revalidate: If ``True``, re-check cached ``SKILL.md`` content
+            on every access using ``If-None-Match`` /
+            ``If-Modified-Since``.  Costs one (usually empty) round
+            trip per access but picks up republished skills.  Defaults
+            to ``False``, which serves cached content until
+            :meth:`invalidate` is called.
+
+    ``SKILL.md`` responses are cached per provider instance, because a
+    single skill is otherwise re-fetched up to five times in one agent
+    session.  Resource fetches (scripts, assets, references) are not
+    cached: they are usually larger and read once.
 
     Example::
 
@@ -109,6 +130,7 @@ class HTTPStaticFileSkillProvider(SkillProvider):
         params: dict[str, str] | None = None,
         require_tls: bool = False,
         max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+        revalidate: bool = False,
     ) -> None:
         if client is not None and (headers is not None or params is not None):
             raise ValueError(
@@ -134,6 +156,8 @@ class HTTPStaticFileSkillProvider(SkillProvider):
 
         self._base_url = base_url.rstrip("/")
         self._max_response_bytes = max_response_bytes
+        self._revalidate = revalidate
+        self._skill_md_cache: dict[str, _CachedSkillMd] = {}
         self._owns_client = client is None
         self._client = client or httpx.AsyncClient(
             headers=headers,
@@ -146,6 +170,18 @@ class HTTPStaticFileSkillProvider(SkillProvider):
         """Close the underlying HTTP client if it is owned by this provider."""
         if self._owns_client:
             await self._client.aclose()
+
+    def invalidate(self, skill_id: str | None = None) -> None:
+        """Drop cached ``SKILL.md`` content.
+
+        Args:
+            skill_id: Skill to forget.  Clears the whole cache when
+                omitted.  Unknown IDs are ignored.
+        """
+        if skill_id is None:
+            self._skill_md_cache.clear()
+        else:
+            self._skill_md_cache.pop(skill_id, None)
 
     async def __aenter__(self) -> HTTPStaticFileSkillProvider:
         return self
@@ -270,8 +306,14 @@ class HTTPStaticFileSkillProvider(SkillProvider):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _stream_bytes(self, url: str, not_found_error: type[Exception]) -> bytes:
-        """Stream a GET request and return the response bytes.
+    async def _stream_bytes(
+        self,
+        url: str,
+        not_found_error: type[Exception],
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> tuple[bytes | None, httpx.Headers]:
+        """Stream a GET request and return the response bytes and headers.
 
         Uses ``httpx.AsyncClient.stream`` so that overly large
         responses are detected **during** download rather than after
@@ -282,6 +324,12 @@ class HTTPStaticFileSkillProvider(SkillProvider):
             not_found_error: Exception type to raise on HTTP 404
                 (e.g. :class:`SkillNotFoundError` or
                 :class:`ResourceNotFoundError`).
+            extra_headers: Additional request headers, used to send
+                conditional-request validators.
+
+        Returns:
+            ``(body, headers)``.  *body* is ``None`` when the server
+            answered ``304 Not Modified``.
 
         Raises:
             not_found_error: On 404.
@@ -289,9 +337,11 @@ class HTTPStaticFileSkillProvider(SkillProvider):
                 the response exceeds *max_response_bytes*.
         """
         try:
-            async with self._client.stream("GET", url) as resp:
+            async with self._client.stream("GET", url, headers=extra_headers) as resp:
                 if resp.status_code == 404:
                     raise not_found_error("Skill content not found")
+                if resp.status_code == 304:
+                    return None, resp.headers
                 try:
                     resp.raise_for_status()
                 except httpx.HTTPStatusError as exc:
@@ -316,24 +366,14 @@ class HTTPStaticFileSkillProvider(SkillProvider):
                             f"Response exceeds maximum size ({self._max_response_bytes} bytes)"
                         )
                     chunks.append(chunk)
+                headers = resp.headers
 
         except (SkillNotFoundError, ResourceNotFoundError, AgentSkillsError):
             raise
         except httpx.HTTPError as exc:
             raise AgentSkillsError("HTTP request failed") from exc
 
-        return b"".join(chunks)
-
-    async def _get_text(self, url: str) -> str:
-        """GET a URL and return the response text.
-
-        Raises:
-            SkillNotFoundError: On 404.
-            AgentSkillsError: On other HTTP or connection errors,
-                or if the response exceeds *max_response_bytes*.
-        """
-        data = await self._stream_bytes(url, SkillNotFoundError)
-        return data.decode("utf-8")
+        return b"".join(chunks), headers
 
     async def _get_bytes(self, url: str) -> bytes:
         """GET a URL and return the response bytes.
@@ -343,13 +383,40 @@ class HTTPStaticFileSkillProvider(SkillProvider):
             AgentSkillsError: On other HTTP or connection errors,
                 or if the response exceeds *max_response_bytes*.
         """
-        return await self._stream_bytes(url, ResourceNotFoundError)
+        data, _ = await self._stream_bytes(url, ResourceNotFoundError)
+        # 304 needs conditional validators, which resource fetches never send.
+        return b"" if data is None else data
 
     async def _get_skill_md(self, skill_id: str) -> str:
-        """Fetch the full text of a skill's ``SKILL.md``."""
+        """Fetch a skill's ``SKILL.md``, serving from cache when possible."""
         self._validate_identifier(skill_id, "skill_id")
         url = f"{self._base_url}/{quote(skill_id, safe='')}/SKILL.md"
-        return await self._get_text(url)
+
+        cached = self._skill_md_cache.get(skill_id)
+        if cached is not None and not self._revalidate:
+            return cached.text
+
+        conditional: dict[str, str] = {}
+        if cached is not None:
+            if cached.etag:
+                conditional["If-None-Match"] = cached.etag
+            if cached.last_modified:
+                conditional["If-Modified-Since"] = cached.last_modified
+
+        data, headers = await self._stream_bytes(
+            url, SkillNotFoundError, extra_headers=conditional or None
+        )
+        if data is None:
+            # 304 is only reachable when validators were sent, which requires a cache entry.
+            return cached.text  # type: ignore[union-attr]
+
+        text = data.decode("utf-8")
+        self._skill_md_cache[skill_id] = _CachedSkillMd(
+            text=text,
+            etag=headers.get("etag"),
+            last_modified=headers.get("last-modified"),
+        )
+        return text
 
     async def _get_resource(self, skill_id: str, subdir: str, name: str) -> bytes:
         """Fetch a single resource file from a skill subdirectory."""

--- a/packages/providers/agentskills-http/tests/test_static.py
+++ b/packages/providers/agentskills-http/tests/test_static.py
@@ -6,7 +6,12 @@ import httpx
 import pytest
 import respx
 
-from agentskills_core import AgentSkillsError, ResourceNotFoundError, SkillNotFoundError
+from agentskills_core import (
+    AgentSkillsError,
+    ResourceNotFoundError,
+    SkillNotFoundError,
+    SkillRegistry,
+)
 from agentskills_http import HTTPStaticFileSkillProvider
 from agentskills_http.static import DEFAULT_TIMEOUT_SECONDS
 
@@ -405,3 +410,94 @@ class TestSecurityEdgeCases:
             assert len(w) == 0
             assert provider._base_url == BASE
             provider._owns_client = False
+
+
+class TestSkillMdCaching:
+    @respx.mock
+    async def test_single_request_across_a_full_session(self):
+        """register -> catalog -> tool call must cost one SKILL.md request."""
+        route = respx.get(f"{BASE}/test-skill/SKILL.md").respond(text=SKILL_MD)
+        async with HTTPStaticFileSkillProvider(BASE) as provider:
+            registry = SkillRegistry()
+            await registry.register("test-skill", provider)
+            await registry.get_skills_catalog()
+            await registry.get_skill("test-skill").get_body()
+            await registry.get_skill("test-skill").get_metadata()
+
+        assert route.call_count == 1
+
+    @respx.mock
+    async def test_resource_fetches_are_not_cached(self):
+        """Only SKILL.md is cached; resources are fetched on demand."""
+        respx.get(f"{BASE}/test-skill/SKILL.md").respond(text=SKILL_MD)
+        route = respx.get(f"{BASE}/test-skill/scripts/run.sh").respond(content=b"echo hi")
+        async with HTTPStaticFileSkillProvider(BASE) as provider:
+            await provider.get_script("test-skill", "run.sh")
+            await provider.get_script("test-skill", "run.sh")
+
+        assert route.call_count == 2
+
+    @respx.mock
+    async def test_cache_is_per_instance(self):
+        route = respx.get(f"{BASE}/test-skill/SKILL.md").respond(text=SKILL_MD)
+        async with HTTPStaticFileSkillProvider(BASE) as first:
+            await first.get_body("test-skill")
+        async with HTTPStaticFileSkillProvider(BASE) as second:
+            await second.get_body("test-skill")
+
+        assert route.call_count == 2
+
+    @respx.mock
+    async def test_invalidate_refetches(self):
+        route = respx.get(f"{BASE}/test-skill/SKILL.md").respond(text=SKILL_MD)
+        async with HTTPStaticFileSkillProvider(BASE) as provider:
+            await provider.get_body("test-skill")
+            provider.invalidate("test-skill")
+            await provider.get_body("test-skill")
+            provider.invalidate()
+            await provider.get_body("test-skill")
+
+        assert route.call_count == 3
+
+    @respx.mock
+    async def test_revalidate_sends_validators_and_honours_304(self):
+        """With revalidate=True the provider re-checks but reuses the body."""
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.headers.get("if-none-match") == '"v1"':
+                return httpx.Response(304)
+            return httpx.Response(200, text=SKILL_MD, headers={"ETag": '"v1"'})
+
+        respx.get(f"{BASE}/test-skill/SKILL.md").mock(side_effect=handler)
+
+        async with HTTPStaticFileSkillProvider(BASE, revalidate=True) as provider:
+            first = await provider.get_body("test-skill")
+            second = await provider.get_body("test-skill")
+
+        assert first == second
+        assert len(requests) == 2
+        assert "if-none-match" not in requests[0].headers
+        assert requests[1].headers["if-none-match"] == '"v1"'
+
+    @respx.mock
+    async def test_revalidate_picks_up_new_content(self):
+        """A 200 during revalidation replaces the cached body."""
+        responses = [
+            httpx.Response(200, text=SKILL_MD, headers={"ETag": '"v1"'}),
+            httpx.Response(
+                200,
+                text=SKILL_MD.replace("body of the test skill", "updated body"),
+                headers={"ETag": '"v2"'},
+            ),
+            httpx.Response(304),
+        ]
+        route = respx.get(f"{BASE}/test-skill/SKILL.md").mock(side_effect=responses)
+
+        async with HTTPStaticFileSkillProvider(BASE, revalidate=True) as provider:
+            assert "updated body" not in await provider.get_body("test-skill")
+            assert "updated body" in await provider.get_body("test-skill")
+            assert "updated body" in await provider.get_body("test-skill")
+
+        assert route.calls[2].request.headers["if-none-match"] == '"v2"'


### PR DESCRIPTION
Implements the three v0.3 performance items.

Caching (item 1): SKILL.md is now cached per provider instance in both the filesystem and HTTP providers, with an explicit invalidate(skill_id=None). A single skill was previously fetched up to five times per agent session. HTTP conditional revalidation (If-None-Match / If-Modified-Since, honouring 304) is opt-in via revalidate=True; the two acceptance criteria conflicted, and paying a round-trip per access is wrong for the common static-host case. Resources are not cached.

Concurrent catalog (item 2): SkillRegistry.get_skills_catalog() fans out metadata fetches with asyncio.gather under a bounded semaphore, configurable via SkillRegistry(catalog_concurrency=8). Output ordering is unchanged. Failures carry the offending skill_id via exc.add_note(), preserving the original exception type.

Non-blocking filesystem I/O (item 3): path resolution, stat and read all run in a worker thread via asyncio.to_thread. anyio was not used to avoid adding a runtime dependency. The whole helper moved off the loop, not just read_text, since the path-traversal guard issues syscalls too.

Also adds .github/copilot-instructions.md recording the branch workflow, and drops a stale v1.0 roadmap row claiming Python 3.14 was blocked upstream.