### PR TITLE
release: 0.3.0

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -205,6 +205,10 @@ All packages share the same version. Use the bump script to update all `pyprojec
 .\scripts\bump-version.ps1 -Bump minor -DryRun
 ```
 
+The script also rewrites each dependent's `agentskills-core` constraint to `>=<new>,<1.0`. The
+six packages ship in lockstep, so a dependent must require the core it was released with —
+otherwise pip can resolve an older core against a newer dependent and fail at import.
+
 ### 2. Commit and merge
 
 Create a branch, commit the version bump, open a PR, and merge to `main`.

--- a/docs/issues/v0.3.md
+++ b/docs/issues/v0.3.md
@@ -789,6 +789,15 @@ issue and in DEVELOPMENT.md rather than left to be discovered.
 is the only remaining path that needs a long-lived token, and the whole point of this change was
 to stop those existing. Left in place per the proposal, but it will drift.
 
+**Found while preparing 0.3.0: the inter-package constraints would have shipped issue 11 again.**
+Every dependent required `agentskills-core = ">=0.1.0,<1.0"`, and `agentskills-mcp-server` had no
+upper bound at all. But `agentskills_mcp_server/config.py` imports `get_logger`, which this
+milestone added — so `pip install agentskills-mcp-server==0.3.0` could legally resolve core
+0.1.0 and fail at import, exactly as the published 0.2.3 packages did. Floors raised to
+`>=0.3.0,<1.0`; `check_release_version.py` now refuses to build unless every dependent requires
+the core version being released, and `bump-version.ps1`/`.sh` rewrite the constraint alongside
+the version so it cannot drift again. The six ship in lockstep, so exact-match is the right rule.
+
 ---
 
 ## 11. Restore compatibility with Agent Framework 1.x

--- a/packages/core/agentskills-core/pyproject.toml
+++ b/packages/core/agentskills-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-core"
-version = "0.2.3"
+version = "0.3.0"
 description = "Storage-agnostic abstractions for discovering, validating, and accessing Agent Skills (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]

--- a/packages/integrations/agentskills-agentframework/pyproject.toml
+++ b/packages/integrations/agentskills-agentframework/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-agentframework"
-version = "0.2.3"
+version = "0.3.0"
 description = "Microsoft Agent Framework integration for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 # 1.0.0 renamed BaseContextProvider to ContextProvider; earlier prereleases are incompatible.
 agent-framework-core = ">=1.0,<2.0"
 

--- a/packages/integrations/agentskills-langchain/pyproject.toml
+++ b/packages/integrations/agentskills-langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-langchain"
-version = "0.2.3"
+version = "0.3.0"
 description = "LangChain integration for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 langchain-core = ">=1.0,<2.0"
 
 [build-system]

--- a/packages/integrations/agentskills-mcp-server/pyproject.toml
+++ b/packages/integrations/agentskills-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-mcp-server"
-version = "0.2.3"
+version = "0.3.0"
 description = "MCP server integration for the Agent Skills format — expose skills as MCP tools and resources (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.1.0"
+agentskills-core = ">=0.3.0,<1.0"
 mcp = ">=1.28.1,<2"
 pydantic = ">=2.0"
 agent-framework-core = {version = ">=1.0,<2.0", optional = true}

--- a/packages/providers/agentskills-fs/pyproject.toml
+++ b/packages/providers/agentskills-fs/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-fs"
-version = "0.2.3"
+version = "0.3.0"
 description = "Filesystem-based skill provider for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 pyyaml = ">=6.0,<7.0"
 
 [build-system]

--- a/packages/providers/agentskills-http/pyproject.toml
+++ b/packages/providers/agentskills-http/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-http"
-version = "0.2.3"
+version = "0.3.0"
 description = "HTTP-based skill providers for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 httpx = ">=0.27,<1.0"
 pyyaml = ">=6.0,<7.0"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,7 +23,7 @@ all = ["agent-framework-a2a", "agent-framework-ag-ui", "agent-framework-anthropi
 
 [[package]]
 name = "agentskills-agentframework"
-version = "0.2.3"
+version = "0.3.0"
 description = "Microsoft Agent Framework integration for the Agent Skills format (https://agentskills.io)"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -33,7 +33,7 @@ develop = true
 
 [package.dependencies]
 agent-framework-core = ">=1.0,<2.0"
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 
 [package.source]
 type = "directory"
@@ -41,7 +41,7 @@ url = "packages/integrations/agentskills-agentframework"
 
 [[package]]
 name = "agentskills-core"
-version = "0.2.3"
+version = "0.3.0"
 description = "Storage-agnostic abstractions for discovering, validating, and accessing Agent Skills (https://agentskills.io)"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -58,7 +58,7 @@ url = "packages/core/agentskills-core"
 
 [[package]]
 name = "agentskills-fs"
-version = "0.2.3"
+version = "0.3.0"
 description = "Filesystem-based skill provider for the Agent Skills format (https://agentskills.io)"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -67,7 +67,7 @@ files = []
 develop = true
 
 [package.dependencies]
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 pyyaml = ">=6.0,<7.0"
 
 [package.source]
@@ -76,7 +76,7 @@ url = "packages/providers/agentskills-fs"
 
 [[package]]
 name = "agentskills-http"
-version = "0.2.3"
+version = "0.3.0"
 description = "HTTP-based skill providers for the Agent Skills format (https://agentskills.io)"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -85,7 +85,7 @@ files = []
 develop = true
 
 [package.dependencies]
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 httpx = ">=0.27,<1.0"
 pyyaml = ">=6.0,<7.0"
 
@@ -95,7 +95,7 @@ url = "packages/providers/agentskills-http"
 
 [[package]]
 name = "agentskills-langchain"
-version = "0.2.3"
+version = "0.3.0"
 description = "LangChain integration for the Agent Skills format (https://agentskills.io)"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -104,7 +104,7 @@ files = []
 develop = true
 
 [package.dependencies]
-agentskills-core = ">=0.1.0,<1.0"
+agentskills-core = ">=0.3.0,<1.0"
 langchain-core = ">=1.0,<2.0"
 
 [package.source]
@@ -113,7 +113,7 @@ url = "packages/integrations/agentskills-langchain"
 
 [[package]]
 name = "agentskills-mcp-server"
-version = "0.2.3"
+version = "0.3.0"
 description = "MCP server integration for the Agent Skills format — expose skills as MCP tools and resources (https://agentskills.io)"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -122,7 +122,7 @@ files = []
 develop = true
 
 [package.dependencies]
-agentskills-core = ">=0.1.0"
+agentskills-core = ">=0.3.0,<1.0"
 mcp = ">=1.28.1,<2"
 pydantic = ">=2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-sdk"
-version = "0.2.3"
+version = "0.3.0"
 description = "Python SDK for the Agent Skills open format (https://agentskills.io)"
 license = "MIT"
 package-mode = false

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -98,6 +98,8 @@ foreach ($relPath in $pyprojectFiles) {
 
     $content = Get-Content $filePath -Raw
     $updated = $content -replace "version = `"$currentVersion`"", "version = `"$newVersion`""
+    # The six ship in lockstep, so a dependent must require the core it ships with.
+    $updated = $updated -replace 'agentskills-core = "[^"]*"', "agentskills-core = `">=$newVersion,<1.0`""
     Set-Content -Path $filePath -Value $updated -NoNewline
     Write-Host "  Updated $relPath" -ForegroundColor Green
 }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -85,10 +85,15 @@ if $DRY_RUN; then
 else
     for rel_path in "${PYPROJECT_FILES[@]}"; do
         file_path="$REPO_ROOT/$rel_path"
+        # The six ship in lockstep, so a dependent must require the core it ships with.
+        sed_args=(
+            -e "s/version = \"$current_version\"/version = \"$new_version\"/"
+            -e "s/agentskills-core = \"[^\"]*\"/agentskills-core = \">=$new_version,<1.0\"/"
+        )
         if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "s/version = \"$current_version\"/version = \"$new_version\"/" "$file_path"
+            sed -i '' "${sed_args[@]}" "$file_path"
         else
-            sed -i "s/version = \"$current_version\"/version = \"$new_version\"/" "$file_path"
+            sed -i "${sed_args[@]}" "$file_path"
         fi
         echo "  Updated $rel_path"
     done

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -19,8 +19,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
 
-PACKAGES = [
-    "packages/core/agentskills-core",
+CORE = "packages/core/agentskills-core"
+
+DEPENDENTS = [
     "packages/providers/agentskills-fs",
     "packages/providers/agentskills-http",
     "packages/integrations/agentskills-langchain",
@@ -28,37 +29,71 @@ PACKAGES = [
     "packages/integrations/agentskills-mcp-server",
 ]
 
+PACKAGES = [CORE, *DEPENDENTS]
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--tag", help="release tag, e.g. v0.3.0")
-    args = parser.parse_args()
 
-    versions: dict[str, str] = {}
-    for package in PACKAGES:
-        manifest = ROOT / package / "pyproject.toml"
-        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
-        versions[Path(package).name] = data["tool"]["poetry"]["version"]
+def _manifest(package: str) -> dict:
+    return tomllib.loads((ROOT / package / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _check_versions(tag: str | None) -> tuple[str | None, list[str]]:
+    """Every package, and the workspace root, must carry the same version."""
+    versions = {Path(p).name: _manifest(p)["tool"]["poetry"]["version"] for p in PACKAGES}
+    versions["(workspace root)"] = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["tool"]["poetry"]["version"]
 
     for name, version in versions.items():
         print(f"  {name:<32} {version}")
 
     distinct = set(versions.values())
     if len(distinct) > 1:
-        print(
-            f"\nERROR: packages disagree on the version: {sorted(distinct)}.\n"
-            "Run scripts/bump-version.ps1 (or .sh) to set them together.",
-            file=sys.stderr,
-        )
-        return 1
+        return None, [
+            f"packages disagree on the version: {sorted(distinct)}. "
+            "Run scripts/bump-version.ps1 (or .sh) to set them together."
+        ]
 
     version = distinct.pop()
-    if args.tag is not None and args.tag != f"v{version}":
-        print(
-            f"\nERROR: tag {args.tag} does not match the packaged version {version}.\n"
-            f"Either the version bump was missed, or the tag should be v{version}.",
-            file=sys.stderr,
-        )
+    if tag is not None and tag != f"v{version}":
+        return version, [
+            f"tag {tag} does not match the packaged version {version}. "
+            f"Either the version bump was missed, or the tag should be v{version}."
+        ]
+    return version, []
+
+
+def _check_core_floor(version: str) -> list[str]:
+    """Dependents must require the core they are released with.
+
+    The six ship in lockstep, so a floor below the release version lets pip
+    resolve an older core against a newer dependent and fail at import.
+    """
+    expected = f">={version},<1.0"
+    errors = []
+    print()
+    for package in DEPENDENTS:
+        found = _manifest(package)["tool"]["poetry"]["dependencies"]["agentskills-core"]
+        print(f"  {Path(package).name:<32} agentskills-core {found}")
+        if found != expected:
+            errors.append(
+                f"{Path(package).name} requires agentskills-core {found!r}, expected {expected!r}."
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="release tag, e.g. v0.3.0")
+    args = parser.parse_args()
+
+    version, errors = _check_versions(args.tag)
+    if version is not None:
+        errors += _check_core_floor(version)
+
+    if errors:
+        print("\nERROR:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
         return 1
 
     print(f"\nOK: all six packages at {version}" + (f", matching {args.tag}" if args.tag else ""))


### PR DESCRIPTION
All twelve v0.3 items are merged.

Preparing the bump surfaced a defect that would have republished issue 11. Every dependent required agentskills-core >=0.1.0,<1.0, and agentskills-mcp-server had no upper bound at all, while agentskills_mcp_server/config.py imports get_logger, which this milestone added. pip install agentskills-mcp-server==0.3.0 could therefore legally resolve core 0.1.0 and fail at import, exactly as the published 0.2.3 packages did.

Floors raised to >=0.3.0,<1.0. check_release_version.py now refuses to build unless every dependent requires the core version being released, and both bump scripts rewrite the constraint alongside the version so it cannot drift again. The six ship in lockstep, so exact-match is the right rule. The version check also covers the workspace root, which bump-version touches but the guard previously ignored.

478 passed, 2 skipped. Coverage 96.42 percent.