### PR TITLE
feat: add the agentskills command line interface

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Working in this repository
 
-Poetry monorepo. Six packages, versioned and released together.
+Poetry monorepo. Seven packages, versioned and released together.
 
 | Path | Package |
 | --- | --- |
@@ -10,6 +10,7 @@ Poetry monorepo. Six packages, versioned and released together.
 | `packages/integrations/agentskills-langchain` | LangChain tools |
 | `packages/integrations/agentskills-agentframework` | Microsoft Agent Framework context provider |
 | `packages/integrations/agentskills-mcp-server` | MCP server + Agent Framework MCP bridge |
+| `packages/cli/agentskills-cli` | `agentskills` command: init, validate, lint, inspect, serve |
 
 Planning lives in `docs/ROADMAP.md`, per-milestone specs in `docs/issues/`, settled
 decisions in `docs/adr/`.
@@ -57,7 +58,7 @@ repository silently matches nothing.
 
 ```bash
 poetry install                                    # after any pyproject change, run poetry lock first
-python -m pytest packages -q --no-header          # baseline: 478 passed, 2 skipped
+python -m pytest packages -q --no-header          # baseline: 553 passed, 2 skipped
 python -m ruff check packages/ examples/       # CI lints these two paths only
 python -m ruff format --check packages/ examples/
 ```
@@ -75,6 +76,11 @@ that task fails for reasons unrelated to your change.
 
 ## Traps worth knowing
 
+- **A new package must be registered in seven places.** Root `pyproject.toml` (path
+  dependency, `[tool.coverage.run] source_pkgs`, `[tool.ruff.lint.isort]
+  known-first-party`), `scripts/dev.py` `COVERAGE_FLOORS`, both `bump-version` scripts,
+  `scripts/check_release_version.py`, and the build loop plus a publish step in
+  `.github/workflows/publish.yml`. Miss the last one and the package silently never ships.
 - **`poetry.lock` hides upstream breaking changes.** Locked installs kept CI green while
   the published packages were broken for every new user. The advisory `test-unlocked` CI
   job resolves without the lock; when it fails, the fix belongs in a version constraint,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,8 @@ jobs:
             packages/providers/agentskills-http \
             packages/integrations/agentskills-langchain \
             packages/integrations/agentskills-agentframework \
-            packages/integrations/agentskills-mcp-server
+            packages/integrations/agentskills-mcp-server \
+            packages/cli/agentskills-cli
           do
             name="$(basename "$pkg")"
             (cd "$pkg" && poetry build)
@@ -96,7 +97,7 @@ jobs:
     name: Publish to ${{ needs.target.outputs.environment }}
     needs: [target, build]
     runs-on: ubuntu-latest
-    # One job, six sequential steps: the environment's reviewers approve the
+    # One job, one step per package: the environment's reviewers approve the
     # release once, not once per package.
     environment:
       name: ${{ needs.target.outputs.environment }}
@@ -157,6 +158,14 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/agentskills-mcp-server
+          repository-url: ${{ env.REPO }}
+          attestations: true
+          skip-existing: true
+
+      - name: agentskills-cli
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/agentskills-cli
           repository-url: ${{ env.REPO }}
           attestations: true
           skip-existing: true

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This project helps you **integrate skills into your own agents**. Retrieve skill
 | [`agentskills-langchain`](packages/integrations/agentskills-langchain/README.md) | **Integration** - expose skills to a LangChain agent as tools. | [![PyPI](https://img.shields.io/pypi/v/agentskills-langchain?label=)](https://pypi.org/project/agentskills-langchain/) | [![Downloads](https://img.shields.io/pepy/dt/agentskills-langchain?label=)](https://pepy.tech/project/agentskills-langchain) |
 | [`agentskills-agentframework`](packages/integrations/agentskills-agentframework/README.md) | **Integration** - expose skills to a Microsoft Agent Framework agent, injected automatically through the agent lifecycle. | [![PyPI](https://img.shields.io/pypi/v/agentskills-agentframework?label=)](https://pypi.org/project/agentskills-agentframework/) | [![Downloads](https://img.shields.io/pepy/dt/agentskills-agentframework?label=)](https://pepy.tech/project/agentskills-agentframework) |
 | [`agentskills-mcp-server`](packages/integrations/agentskills-mcp-server/README.md) | **Integration** - serve skills over the Model Context Protocol to any MCP client, such as Claude Desktop, VS Code, or Cursor. | [![PyPI](https://img.shields.io/pypi/v/agentskills-mcp-server?label=)](https://pypi.org/project/agentskills-mcp-server/) | [![Downloads](https://img.shields.io/pepy/dt/agentskills-mcp-server?label=)](https://pepy.tech/project/agentskills-mcp-server) |
+| [`agentskills-cli`](packages/cli/agentskills-cli/README.md) | **Tooling** - the `agentskills` command: scaffold, validate, lint, and inspect skills. | [![PyPI](https://img.shields.io/pypi/v/agentskills-cli?label=)](https://pypi.org/project/agentskills-cli/) | [![Downloads](https://img.shields.io/pepy/dt/agentskills-cli?label=)](https://pepy.tech/project/agentskills-cli) |
 
 **Which do I need?** One provider for wherever your skills live, plus the integration for your
 agent framework. Both pull in `agentskills-core`, so a LangChain app reading skills from disk
@@ -33,6 +34,8 @@ needs only:
 ```bash
 pip install agentskills-fs agentskills-langchain
 ```
+
+If you *write* skills rather than consume them, you want `agentskills-cli` instead.
 
 ## How It Works
 
@@ -295,6 +298,34 @@ async with mcp_skills:
 ```
 
 See [examples/agent-framework/](examples/agent-framework/) for full working demos.
+
+## Command Line
+
+`agentskills-cli` is for authoring skills rather than consuming them.
+
+```bash
+pip install agentskills-cli
+```
+
+```bash
+agentskills init incident-response --path ./skills   # scaffold a skill that validates
+agentskills validate ./skills                        # exits 1 on any error
+agentskills lint ./skills                            # legal, but costly
+agentskills inspect ./skills/incident-response       # what the agent actually receives
+agentskills serve ./skills                           # MCP server, no config file
+```
+
+`validate` is the one to put in CI. It exits `1` when a skill is broken and `2` when the
+invocation is, so a workflow can tell those apart, and `--format json` emits a documented,
+versioned schema:
+
+```yaml
+- run: pip install agentskills-cli
+- run: agentskills validate ./skills
+```
+
+See the [package README](packages/cli/agentskills-cli/README.md) for the lint rules, the JSON
+schema, and the exit codes.
 
 ## Custom Providers
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -32,6 +32,7 @@ poetry run pytest packages/providers/agentskills-http -v
 poetry run pytest packages/integrations/agentskills-langchain -v
 poetry run pytest packages/integrations/agentskills-agentframework -v
 poetry run pytest packages/integrations/agentskills-mcp-server -v
+poetry run pytest packages/cli/agentskills-cli -v
 ```
 
 ### Coverage
@@ -206,7 +207,7 @@ All packages share the same version. Use the bump script to update all `pyprojec
 ```
 
 The script also rewrites each dependent's `agentskills-core` constraint to `>=<new>,<1.0`. The
-six packages ship in lockstep, so a dependent must require the core it was released with —
+packages ship in lockstep, so a dependent must require the core it was released with —
 otherwise pip can resolve an older core against a newer dependent and fail at import.
 
 ### 2. Commit and merge
@@ -229,8 +230,8 @@ malformed tag cannot burn a real version number.
 
 ### 4. Approve
 
-`.github/workflows/publish.yml` builds all six distributions, then waits on the `pypi`
-environment for a reviewer. Approving releases all six packages; there is one approval per
+`.github/workflows/publish.yml` builds every distribution, then waits on the `pypi`
+environment for a reviewer. Approving releases all of them; there is one approval per
 release, not one per package.
 
 Publishing uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — the
@@ -303,5 +304,6 @@ This is worth knowing before adding a seventh package, or publishing to any new 
 | `packages/integrations/agentskills-langchain` | Integrate skills with LangChain agents |
 | `packages/integrations/agentskills-agentframework` | Integrate skills with Microsoft Agent Framework agents |
 | `packages/integrations/agentskills-mcp-server` | MCP server for exposing skills as MCP tools and resources (`agentskills-mcp-server` on PyPI) |
+| `packages/cli/agentskills-cli` | The `agentskills` command: `init`, `validate`, `lint`, `inspect`, `serve` |
 
-Each package has its own `pyproject.toml` under `packages/` and can be published independently. `agentskills-fs`, `agentskills-http`, `agentskills-langchain`, `agentskills-agentframework`, and `agentskills-mcp-server` depend on `agentskills-core`. The root `pyproject.toml` uses Poetry to manage workspace-level dependencies and installs all packages in editable mode.
+Each package has its own `pyproject.toml` under `packages/` and can be published independently. Every package except `agentskills-core` depends on it. The root `pyproject.toml` uses Poetry to manage workspace-level dependencies and installs all packages in editable mode.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,7 +76,7 @@ provably correct. Specifications: [docs/issues/v0.4.md](./issues/v0.4.md).
 
 | Item | Theme | Package(s) | Notes |
 |---|---|---|---|
-| `agentskills` CLI | DX | new `agentskills-cli` | `init` (scaffold a skill), `validate <path>` (spec check, exit non-zero on failure), `lint` (style/token-budget warnings), `inspect` (render catalog/metadata), `serve` (run the MCP server without writing config by hand). |
+| `agentskills` CLI | DX | new `agentskills-cli` | **Implemented, awaiting release.** `init` (scaffold a skill), `validate <path>` (spec check, exit non-zero on failure), `lint` (style/token-budget warnings), `inspect` (render catalog/metadata), `serve` (run the MCP server without writing config by hand). Separate package and stdlib `argparse` so the validation Action inherits no dependencies; `serve` is an optional extra. |
 | Skill validation GitHub Action | DX | repo | Thin wrapper over `agentskills validate` so skill repos can gate PRs. Highest-leverage adoption lever — it puts the SDK in other people's CI. |
 | Provider conformance test kit | Correctness | new `agentskills-testing` | A published pytest suite any third-party provider can run to prove it satisfies the `SkillProvider` contract (traversal safety, size limits, error types, resource listing). Turns the protocol into a real, testable interface. |
 | Test doubles | DX | `agentskills-testing` | `InMemorySkillProvider` + fixtures so downstream users can unit-test agents without disk or network. |
@@ -87,7 +87,7 @@ provably correct. Specifications: [docs/issues/v0.4.md](./issues/v0.4.md).
 | Token cost reporting | DX | `agentskills-cli` | `agentskills inspect --cost` breaking down tokens by catalog entry, body section, and resource. Authors cannot budget what they cannot see. |
 | Documentation site | Project health | repo | MkDocs Material with API reference, versioned per release. README is already carrying more than it should. |
 | Architecture decision records | Project health | `docs/adr/` | Short ADRs for cross-package decisions (async model, caching strategy, error taxonomy, packaging). |
-| Simplify the publish workflow | Project health | repo | Drop the TestPyPI dry-run path. Pending trusted publishers must be uniquely identifiable by their claims, and all six distributions share owner, repo, workflow and environment — so only one pending publisher can exist at a time, and bootstrapping six projects on a fresh index takes six sequential publish rounds. The result is a dry run configured for one package out of six, which fails in a way that looks like a real problem. Replace the fall-through routing with an explicit refusal for unexpected tag shapes, make `workflow_dispatch` build-only, and let pre-releases go to PyPI, which handles them natively. |
+| Simplify the publish workflow | Project health | repo | Drop the TestPyPI dry-run path. Pending trusted publishers must be uniquely identifiable by their claims, and all seven distributions share owner, repo, workflow and environment — so only one pending publisher can exist at a time, and bootstrapping them on a fresh index takes one sequential publish round each. The result is a dry run configured for one package out of seven, which fails in a way that looks like a real problem. Replace the fall-through routing with an explicit refusal for unexpected tag shapes, make `workflow_dispatch` build-only, and let pre-releases go to PyPI, which handles them natively. |
 
 ---
 

--- a/docs/issues/v0.4.md
+++ b/docs/issues/v0.4.md
@@ -11,6 +11,9 @@ Add the GitHub issue number to a heading once the item is filed.
 
 **Labels:** `theme:dx`, `type:feature`, `package:cli`
 
+> **Status: implemented.** Both open questions were resolved toward the dependency-light
+> answer; see the implementation notes.
+
 ### Problem
 
 There is no way to work with a skill without writing Python. Validation only happens inside
@@ -40,12 +43,69 @@ integration.
 
 ### Acceptance criteria
 
-- [ ] All five commands implemented with `--help`
-- [ ] `validate` exits non-zero on any failure and zero on success
-- [ ] `validate` handles both a single skill folder and a directory of skills
-- [ ] `--format json` output is stable and documented
-- [ ] Installs without any framework integration dependency
-- [ ] Package README with examples
+- [x] All five commands implemented with `--help`
+- [x] `validate` exits non-zero on any failure and zero on success
+- [x] `validate` handles both a single skill folder and a directory of skills
+- [x] `--format json` output is stable and documented
+- [x] Installs without any framework integration dependency
+- [x] Package README with examples
+
+### Implementation notes
+
+**Both open questions were answered the same way, for the same reason.** A separate
+`agentskills-cli` package rather than `agentskills-core[cli]`, and stdlib `argparse` rather
+than `click` or `typer`. Item 2 installs this CLI into other people's CI, so every dependency
+it carries is a supply-chain edge those repositories inherit for the privilege of checking a
+markdown file. `argparse` costs some polish in `--help`; that is the whole price.
+
+The MCP server is an optional `serve` extra for the same reason: `mcp` and `pydantic` have no
+business being installed by a job that only runs `validate`.
+
+**The forgiving parser was the actual problem worth solving.**
+`split_frontmatter()` returns `({}, raw)` on a YAML error rather than raising — a
+deliberate choice in core, since a provider should not explode on one bad skill. But it means
+a mistyped colon arrives at `validate_skill()` as "metadata missing required 'name'" and
+"metadata missing required 'description'", which tells an author nothing about what is wrong.
+The CLI therefore parses the frontmatter itself first and reports the real cause: missing
+delimiter, unclosed block, oversized block, invalid YAML, or a sequence where a mapping
+belongs. Spec checks are skipped when that fails, because they can only restate the damage.
+
+This is also where line numbers come from. `problem_mark.line + 1` maps a YAML error back to
+a `SKILL.md` line, which is exactly what item 2 needs to annotate a pull request diff inline —
+without it the Action can only annotate at file level.
+
+**Exit code 2 exists to keep "found a problem" apart from "could not look".** A missing path,
+an uninstalled extra, and an unwritable directory all exit 2; broken skills exit 1. A workflow
+that collapses every non-zero into "invalid skill" reports a typo in a path as a spec
+violation, and the author goes looking for a fault in a file that is fine.
+
+**The scaffold is validated before it is written.** `init` builds an in-memory provider over
+the template and runs the real `validate_skill()` against it. That rejects `init "Bad Name"`
+without copying `_NAME_RE` into this package, and it means the template we ship cannot quietly
+drift out of conformance — if the spec tightens, `init` starts failing its own output.
+
+**Lint thresholds are opinions, so they are named and adjustable.** `--max-body-tokens` is a
+flag; the 500-character catalog description ceiling is a constant with the reasoning attached
+(a catalog entry is charged on every turn, a body only when loaded). Token counts are
+`len(text) / 4`, which is honest enough to flag an outlier and nowhere near a real tokenizer.
+
+### Observations for later
+
+**`lint` cannot warn about unknown frontmatter keys.** Core recognises exactly seven, warns
+about anything else at registration, and keeps that set in a private `_KNOWN_KEYS`. Surfacing
+it here would mean duplicating the constant in a second package — the drift trap already on
+the follow-ups list. Core should export the known-key set; until it does, this lint is absent
+rather than wrong.
+
+**A seventh package must be registered in seven places** — root `pyproject.toml` three times
+(path dependency, `source_pkgs`, isort first-party), `COVERAGE_FLOORS`, both bump scripts,
+`check_release_version.py`, and `publish.yml` twice (build loop and publish step). Only the
+last one fails silently: everything else errors, but a package missing from `publish.yml`
+simply never ships. Recorded in `.github/copilot-instructions.md`.
+
+**`agentskills-cli` is a new PyPI project**, so it needs a pending trusted publisher registered
+before the v0.4.0 tag — and the pending-publisher uniqueness limit documented in item 12 means
+it cannot be registered alongside another pending one.
 
 ---
 
@@ -338,6 +398,11 @@ dependency.
 
 **Labels:** `theme:dx`, `type:feature`, `package:cli`, `good-first-issue`
 
+> **Partly answered by item 1.** `inspect` already reports the catalog entry and body with an
+> estimate, and `lint` enforces a body budget — but both count `len(text) / 4`. What is left
+> here is the per-section breakdown and a real tokenizer, which means deciding whether the CLI
+> takes a `tiktoken` dependency or ships the estimate with the caveat attached.
+
 ### Problem
 
 Skill authors have no visibility into what their skill costs. The catalog entry is charged on
@@ -447,12 +512,13 @@ Add a short `docs/adr/README.md` with the template and the numbering convention.
 ### Problem
 
 The publish workflow routes any tag that is not a bare `vX.Y.Z` to TestPyPI as a dry run. That
-path is configured for exactly one of the six packages, and finishing it is more work than it
-looks: **pending trusted publishers must be uniquely identifiable by their claims.** All six
+path is configured for exactly one of the seven packages, and finishing it is more work than it
+looks: **pending trusted publishers must be uniquely identifiable by their claims.** All seven
 distributions share the same owner, repository, workflow and environment, so PyPI cannot tell
 which pending project an incoming token belongs to and permits only one pending publisher at a
-time. Bootstrapping six projects on a fresh index therefore takes six sequential publish rounds,
-each one converting a pending publisher into a project-scoped one and freeing the slot.
+time. Bootstrapping the set on a fresh index therefore takes as many sequential publish rounds
+as there are packages, each one converting a pending publisher into a project-scoped one and
+freeing the slot.
 
 So today an `rc` tag publishes `agentskills-core` and then fails. That is worse than having no
 dry run, because it fails in a way that looks like a real problem.
@@ -504,6 +570,7 @@ Surfaced during v0.3 and too small for a roadmap row. Good first issues unless n
 | Widen the lint scope to `scripts/` | CI lints `packages/` and `examples/` only, so `scripts/dev.py` has drifted from the formatter. Widen the scope and reformat once, deliberately. |
 | Coverage ratchet targets | `mcp_server/__main__.py` at 75% — the documented launch path is untested. `mcp_server/context_provider.py` at 83% — the import guard's two upgrade messages have never executed. |
 | `_KNOWN_KEYS` and `_OPTIONAL_FIELDS` are out of step | A third specially-validated field should trigger converting the table to `{name: validator}`. |
+| Export the known frontmatter keys from core | `agentskills lint` cannot warn about unknown keys without duplicating a private constant in a second package. Exporting the set makes the lint a few lines; until then it is absent. From v0.4 item 1. |
 | Semver comparison | The inlined regex validates but cannot compare. Adopt the `semver` package only if range matching is actually needed. |
 | No timing instrumentation | v0.3 item 8 asked how long a fetch took, and nothing answers that. Deferred deliberately to OpenTelemetry in v0.6 rather than hand-rolled `time.monotonic()` deltas. |
 

--- a/packages/cli/agentskills-cli/README.md
+++ b/packages/cli/agentskills-cli/README.md
@@ -1,0 +1,172 @@
+# agentskills-cli
+
+Command line tools for authoring and validating [Agent Skills](https://agentskills.io).
+
+Part of the [Agent Skills SDK](https://github.com/pratikxpanda/agentskills-sdk).
+
+## Install
+
+```bash
+pip install agentskills-cli
+```
+
+The `serve` command needs the MCP server, which is an optional extra so that
+validating skills in CI does not pull in `mcp` and `pydantic`:
+
+```bash
+pip install "agentskills-cli[serve]"
+```
+
+## Commands
+
+Every command takes either one skill folder or a folder of skill folders — the
+one containing `SKILL.md`, or the one containing directories that do.
+
+| Command | What it does |
+| --- | --- |
+| `agentskills init <name>` | Scaffold a skill that already validates. |
+| `agentskills validate <path>` | Check skills against the specification. Exits `1` on any error. |
+| `agentskills lint <path>` | Report what is legal but still costly. |
+| `agentskills inspect <path>` | Show what an agent would actually receive. |
+| `agentskills serve <path>` | Run an MCP server over a folder of skills. |
+
+### `init`
+
+```bash
+agentskills init incident-response --path ./skills
+```
+
+Creates `skills/incident-response/` with a valid `SKILL.md` and empty
+`references/`, `scripts/`, and `assets/` directories. The template is validated
+before anything is written, so an unusable name is refused rather than
+scaffolded.
+
+### `validate`
+
+```bash
+agentskills validate ./skills
+```
+
+```text
+skills/incident-response
+  ok
+skills/broken-skill
+  error   frontmatter-invalid-yaml (line 3): frontmatter is not valid YAML: mapping values are not allowed here
+
+2 skills checked, 1 error, 0 warnings
+```
+
+Frontmatter is parsed by the CLI before the skill reaches the SDK's validator.
+The SDK's parser is deliberately forgiving — malformed YAML yields an empty
+mapping — which downstream reads as "no name, no description" and tells you
+nothing about the colon you missed.
+
+### `lint`
+
+```bash
+agentskills lint ./skills --strict --max-body-tokens 4000
+```
+
+| Code | Warning |
+| --- | --- |
+| `missing-version` | No `version`, so consumers cannot pin the skill or detect drift. |
+| `description-too-long-for-catalog` | Catalog entries sit in context every turn. |
+| `body-over-token-budget` | Body is large enough that detail belongs in `references/`. |
+| `unreferenced-resource` | A file the body never mentions is a file no agent will load. |
+
+Warnings do not fail the command unless `--strict` is passed.
+
+### `inspect`
+
+```bash
+agentskills inspect ./skills/incident-response
+```
+
+Prints the metadata, the resource list, the catalog entry the agent sees on
+every turn, and the body it loads on demand — each with an estimated token
+cost, so you can see the price before shipping.
+
+### `serve`
+
+```bash
+agentskills serve ./skills --transport stdio
+```
+
+Runs the MCP server over a folder of skills without hand-writing a config
+file. For anything beyond a single filesystem root — HTTP providers,
+per-skill options, environment placeholders — use
+[agentskills-mcp-server](https://github.com/pratikxpanda/agentskills-sdk/tree/main/packages/integrations/agentskills-mcp-server)
+with a `server.json`.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Ran, found nothing wrong. |
+| `1` | Ran, found errors — or warnings under `--strict`. |
+| `2` | Could not run: bad path, missing extra, unwritable directory. |
+
+The distinction matters in CI: `1` means a skill is broken, `2` means the
+invocation is.
+
+## JSON output
+
+`validate`, `lint`, and `inspect` accept `--format json`. The schema is a
+published contract; `schemaVersion` is bumped only for a breaking change, and
+new fields are added rather than existing ones repurposed.
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "validate",
+  "ok": false,
+  "summary": { "skills": 2, "errors": 1, "warnings": 0 },
+  "skills": [
+    {
+      "id": "broken-skill",
+      "path": "skills/broken-skill",
+      "ok": false,
+      "findings": [
+        {
+          "severity": "error",
+          "code": "frontmatter-invalid-yaml",
+          "message": "frontmatter is not valid YAML: mapping values are not allowed here",
+          "line": 3
+        }
+      ]
+    }
+  ]
+}
+```
+
+`ok` mirrors the exit code, so a consumer never has to re-derive the
+strictness rules. `line` is `null` unless the problem can be attributed to one
+line of `SKILL.md`.
+
+## Continuous integration
+
+```yaml
+- run: pip install agentskills-cli
+- run: agentskills validate ./skills
+```
+
+## Logging
+
+Pass `-v` to send the SDK's debug logs to stderr, leaving stdout parseable:
+
+```bash
+agentskills validate ./skills --format json -v > report.json
+```
+
+## Security
+
+Agent Skills are **equivalent to executable code** — skill content is injected
+into an LLM agent's context verbatim. Validating a skill does not make it safe
+to run. **Only load skills from sources you trust.**
+
+See
+[SECURITY.md](https://github.com/pratikxpanda/agentskills-sdk/blob/main/SECURITY.md).
+
+## License
+
+MIT

--- a/packages/cli/agentskills-cli/agentskills_cli/__init__.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/__init__.py
@@ -1,0 +1,20 @@
+"""Command line tools for authoring and validating Agent Skills.
+
+The console script is ``agentskills``.  Every command is also reachable
+in-process through :func:`~agentskills_cli.cli.main`, which takes an
+argument list and returns an exit code rather than calling
+:func:`sys.exit` — that is what makes it testable.
+"""
+
+from agentskills_cli.cli import main
+from agentskills_cli.discovery import CliError, SkillLocation, discover
+from agentskills_cli.findings import Finding, SkillReport
+
+__all__ = [
+    "CliError",
+    "Finding",
+    "SkillLocation",
+    "SkillReport",
+    "discover",
+    "main",
+]

--- a/packages/cli/agentskills-cli/agentskills_cli/__main__.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point for ``python -m agentskills_cli`` and the ``agentskills`` script."""
+
+from __future__ import annotations
+
+import sys
+
+from agentskills_cli.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/cli/agentskills-cli/agentskills_cli/cli.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/cli.py
@@ -1,0 +1,235 @@
+"""Argument parsing and dispatch for the ``agentskills`` command.
+
+Exit codes are the contract CI depends on:
+
+* ``0`` — the command ran and found nothing wrong.
+* ``1`` — the command ran and found errors (or, under ``--strict``,
+  warnings).
+* ``2`` — the command could not run: a bad path, a missing extra, an
+  unwritable directory.
+
+Keeping "found a problem" distinct from "could not look" means a
+workflow can tell a broken skill from a broken invocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+from agentskills_cli.discovery import CliError, SkillLocation, discover, relative_to_cwd
+from agentskills_cli.inspection import inspect_location, render_inspection_text
+from agentskills_cli.lint import DEFAULT_BODY_TOKEN_BUDGET, lint_locations
+from agentskills_cli.render import SCHEMA_VERSION, exit_code, plural, render_json, render_text
+from agentskills_cli.scaffold import DEFAULT_DESCRIPTION, init_skill
+from agentskills_cli.serve import build_registry, create_server
+from agentskills_cli.validate import validate_locations
+from agentskills_core import LOGGER_NAMESPACE
+
+EXIT_OK = 0
+EXIT_FINDINGS = 1
+EXIT_ERROR = 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``agentskills`` argument parser."""
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print the SDK's debug logs to stderr.",
+    )
+
+    formatted = argparse.ArgumentParser(add_help=False)
+    formatted.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text).",
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="agentskills",
+        description="Author, validate, and serve Agent Skills.",
+        parents=[common],
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init = subparsers.add_parser(
+        "init",
+        parents=[common],
+        help="Scaffold a new skill.",
+        description="Scaffold a new skill directory that already validates.",
+    )
+    init.add_argument("name", help="Skill name, also used as the directory name.")
+    init.add_argument(
+        "--path",
+        type=Path,
+        default=Path("."),
+        help="Directory to create the skill in (default: the working directory).",
+    )
+    init.add_argument(
+        "--description",
+        default=DEFAULT_DESCRIPTION,
+        help="Frontmatter description for the new skill.",
+    )
+
+    validate = subparsers.add_parser(
+        "validate",
+        parents=[common, formatted],
+        help="Check skills against the specification.",
+        description="Check one skill or a directory of skills. Exits 1 on any error.",
+    )
+    validate.add_argument("path", type=Path, help="A skill folder or a folder of skills.")
+
+    lint = subparsers.add_parser(
+        "lint",
+        parents=[common, formatted],
+        help="Report quality warnings.",
+        description="Report problems that are legal per the spec but still cost you.",
+    )
+    lint.add_argument("path", type=Path, help="A skill folder or a folder of skills.")
+    lint.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on warnings as well as errors.",
+    )
+    lint.add_argument(
+        "--max-body-tokens",
+        type=int,
+        default=DEFAULT_BODY_TOKEN_BUDGET,
+        metavar="N",
+        help=f"Estimated body token budget (default: {DEFAULT_BODY_TOKEN_BUDGET}).",
+    )
+
+    inspect = subparsers.add_parser(
+        "inspect",
+        parents=[common, formatted],
+        help="Show what an agent would receive.",
+        description="Render the catalog entry, metadata, and body, with estimated token cost.",
+    )
+    inspect.add_argument("path", type=Path, help="A skill folder or a folder of skills.")
+
+    serve = subparsers.add_parser(
+        "serve",
+        parents=[common],
+        help="Run an MCP server over a folder of skills.",
+        description="Run an MCP server over a folder of skills, with no config file.",
+    )
+    serve.add_argument("path", type=Path, help="A skill folder or a folder of skills.")
+    serve.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="stdio",
+        help="MCP transport (default: stdio).",
+    )
+    serve.add_argument(
+        "--name",
+        default="Agent Skills",
+        help="Display name advertised by the server.",
+    )
+
+    return parser
+
+
+def _enable_debug_logging() -> None:
+    """Send the SDK's own logs to stderr, leaving stdout parseable."""
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    logger = logging.getLogger(LOGGER_NAMESPACE)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+
+def _run_init(args: argparse.Namespace, out: TextIO) -> int:
+    target = asyncio.run(init_skill(args.name, args.path, args.description))
+    print(f"Created {relative_to_cwd(target)}", file=out)
+    return EXIT_OK
+
+
+def _run_validate(args: argparse.Namespace, out: TextIO) -> int:
+    root, locations = discover(args.path)
+    reports = asyncio.run(validate_locations(root, locations))
+    if args.format == "json":
+        render_json("validate", reports, out)
+    else:
+        render_text(reports, out)
+    return exit_code(reports)
+
+
+def _run_lint(args: argparse.Namespace, out: TextIO) -> int:
+    root, locations = discover(args.path)
+    reports = asyncio.run(lint_locations(root, locations, body_token_budget=args.max_body_tokens))
+    if args.format == "json":
+        render_json("lint", reports, out, strict=args.strict)
+    else:
+        render_text(reports, out)
+    return exit_code(reports, strict=args.strict)
+
+
+async def _inspect_all(root: Path, locations: list[SkillLocation]) -> list[dict[str, Any]]:
+    return [await inspect_location(root, location) for location in locations]
+
+
+def _run_inspect(args: argparse.Namespace, out: TextIO) -> int:
+    root, locations = discover(args.path)
+    inspections = asyncio.run(_inspect_all(root, locations))
+    if args.format == "json":
+        payload = {
+            "schemaVersion": SCHEMA_VERSION,
+            "command": "inspect",
+            "skills": inspections,
+        }
+        json.dump(payload, out, indent=2)
+        print(file=out)
+    else:
+        for index, inspection in enumerate(inspections):
+            if index:
+                print("\n" + "-" * 60 + "\n", file=out)
+            render_inspection_text(inspection, out)
+    return EXIT_OK
+
+
+def _run_serve(args: argparse.Namespace, out: TextIO) -> int:
+    root, locations = discover(args.path)
+    registry = asyncio.run(build_registry(root, locations))
+    server = create_server(registry, name=args.name)
+    print(f"Serving {plural(len(locations), 'skill')} over {args.transport}", file=sys.stderr)
+    server.run(transport=args.transport)
+    return EXIT_OK
+
+
+_COMMANDS = {
+    "init": _run_init,
+    "validate": _run_validate,
+    "lint": _run_lint,
+    "inspect": _run_inspect,
+    "serve": _run_serve,
+}
+
+
+def main(argv: list[str] | None = None, out: TextIO | None = None) -> int:
+    """Run the ``agentskills`` command line.
+
+    Args:
+        argv: Arguments to parse.  Defaults to ``sys.argv[1:]``.
+        out: Stream to write reports to.  Defaults to stdout.
+
+    Returns:
+        A process exit code.
+    """
+    args = build_parser().parse_args(argv)
+    if args.verbose:
+        _enable_debug_logging()
+
+    try:
+        return _COMMANDS[args.command](args, out or sys.stdout)
+    except CliError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR

--- a/packages/cli/agentskills-cli/agentskills_cli/discovery.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/discovery.py
@@ -1,0 +1,93 @@
+"""Locate skills on disk.
+
+Every command takes a path that is either one skill folder or a folder
+of them.  Resolving that ambiguity in one place keeps the commands from
+each inventing their own answer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from agentskills_core import get_logger
+
+SKILL_FILE = "SKILL.md"
+
+_logger = get_logger(__name__)
+
+
+class CliError(Exception):
+    """A problem with the invocation itself, not with a skill.
+
+    Raised for a missing path or an empty directory — conditions that
+    mean the command could not run, as opposed to running and finding
+    fault with a skill.
+    """
+
+
+@dataclass(frozen=True)
+class SkillLocation:
+    """One skill directory and the ID it will be registered under."""
+
+    skill_id: str
+    path: Path
+
+
+def discover(target: Path) -> tuple[Path, list[SkillLocation]]:
+    """Resolve *target* into a provider root and the skills beneath it.
+
+    A directory containing ``SKILL.md`` is a single skill, and its
+    parent becomes the provider root because
+    :class:`~agentskills_fs.LocalFileSystemSkillProvider` addresses
+    skills by directory name below a root.  Any other directory is
+    treated as a collection, and each immediate subdirectory holding a
+    ``SKILL.md`` is one skill.
+
+    Args:
+        target: Path to a skill folder or a folder of skill folders.
+
+    Returns:
+        A ``(root, locations)`` tuple.  *locations* is sorted by skill
+        ID and is never empty.
+
+    Raises:
+        CliError: If *target* is not a directory, or is a directory with
+            no skills in it.
+    """
+    resolved = target.expanduser().resolve()
+
+    if not resolved.is_dir():
+        raise CliError(f"not a directory: {target}")
+
+    if (resolved / SKILL_FILE).is_file():
+        _logger.debug("Resolved %s as a single skill", resolved)
+        return resolved.parent, [SkillLocation(resolved.name, resolved)]
+
+    locations = [
+        SkillLocation(child.name, child)
+        for child in sorted(resolved.iterdir())
+        if child.is_dir() and (child / SKILL_FILE).is_file()
+    ]
+
+    if not locations:
+        raise CliError(
+            f"no skills found in {target}: expected {SKILL_FILE} there "
+            f"or in an immediate subdirectory"
+        )
+
+    _logger.debug("Resolved %s as %d skills", resolved, len(locations))
+    return resolved, locations
+
+
+def relative_to_cwd(path: Path) -> str:
+    """Render *path* relative to the working directory when possible.
+
+    Machine consumers annotate files by repository-relative path, so a
+    relative form is preferred.  A path on another drive has no relative
+    form on Windows; that falls back to absolute.
+    """
+    try:
+        return path.relative_to(Path.cwd()).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/packages/cli/agentskills-cli/agentskills_cli/findings.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/findings.py
@@ -1,0 +1,60 @@
+"""Findings — the single currency every command reports in.
+
+``validate`` and ``lint`` differ only in which findings they produce and
+whether those findings fail the build.  Modelling both as a list of
+:class:`Finding` keeps one renderer for human output and one JSON schema
+for machines, so a consumer that can read ``validate`` output can read
+``lint`` output too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+ERROR = "error"
+WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single problem found in a skill.
+
+    Attributes:
+        severity: Either ``"error"`` or ``"warning"``.
+        code: Stable machine-readable identifier, e.g.
+            ``"frontmatter-invalid-yaml"``.  Callers may key off this;
+            *message* is free to be reworded.
+        message: Human-readable explanation.
+        line: 1-based line in ``SKILL.md``, when the problem can be
+            attributed to one.  ``None`` otherwise.
+    """
+
+    severity: str
+    code: str
+    message: str
+    line: int | None = None
+
+
+@dataclass(frozen=True)
+class SkillReport:
+    """Every finding for one skill."""
+
+    skill_id: str
+    path: Path
+    findings: list[Finding]
+
+    @property
+    def errors(self) -> list[Finding]:
+        """Findings with ``error`` severity."""
+        return [f for f in self.findings if f.severity == ERROR]
+
+    @property
+    def warnings(self) -> list[Finding]:
+        """Findings with ``warning`` severity."""
+        return [f for f in self.findings if f.severity == WARNING]
+
+    @property
+    def ok(self) -> bool:
+        """``True`` when the skill produced no error-severity findings."""
+        return not self.errors

--- a/packages/cli/agentskills-cli/agentskills_cli/inspection.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/inspection.py
@@ -1,0 +1,82 @@
+"""``agentskills inspect`` — show what an agent would actually receive.
+
+A skill is only as good as what lands in the context window, and that
+is not the file on disk: it is the catalog entry plus, once the agent
+asks for it, the body.  Showing both with their estimated cost lets an
+author see the price before shipping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TextIO
+
+from agentskills_cli.discovery import CliError, SkillLocation, relative_to_cwd
+from agentskills_cli.lint import estimate_tokens
+from agentskills_core import Skill, SkillRegistry, get_logger
+from agentskills_fs import LocalFileSystemSkillProvider
+
+_logger = get_logger(__name__)
+
+
+async def inspect_location(root: Path, location: SkillLocation) -> dict[str, Any]:
+    """Return everything ``inspect`` reports for one skill.
+
+    Raises:
+        CliError: If the skill does not validate.  Registration is what
+            an application would do, so failing here is the truthful
+            answer rather than rendering something no agent could load.
+    """
+    provider = LocalFileSystemSkillProvider(root)
+    registry = SkillRegistry()
+    try:
+        await registry.register(location.skill_id, provider)
+    except ValueError as exc:
+        raise CliError(
+            f"cannot inspect '{location.skill_id}': it does not validate — {exc}"
+        ) from exc
+
+    skill = Skill(location.skill_id, provider)
+    metadata = await skill.get_metadata()
+    body = await skill.get_body()
+    catalog = await registry.get_skills_catalog(format="xml")
+    resources = await skill.list_resources() if skill.supports_resource_listing else {}
+
+    _logger.debug("Inspected %s", location.skill_id)
+    return {
+        "id": location.skill_id,
+        "path": relative_to_cwd(location.path),
+        "metadata": metadata,
+        "catalogEntry": catalog,
+        "body": body,
+        "resources": resources,
+        "estimatedTokens": {
+            "catalogEntry": estimate_tokens(catalog),
+            "body": estimate_tokens(body),
+        },
+    }
+
+
+def render_inspection_text(inspection: dict[str, Any], out: TextIO) -> None:
+    """Write one inspection in human-readable form."""
+    tokens = inspection["estimatedTokens"]
+    print(f"{inspection['path']}  ({inspection['id']})", file=out)
+
+    print("\nmetadata", file=out)
+    for key, value in inspection["metadata"].items():
+        print(f"  {key}: {value}", file=out)
+
+    resources = inspection["resources"]
+    print("\nresources", file=out)
+    if any(resources.values()):
+        for kind, names in resources.items():
+            for name in names:
+                print(f"  {kind}/{name}", file=out)
+    else:
+        print("  none", file=out)
+
+    print(f"\ncatalog entry  (~{tokens['catalogEntry']} tokens, always in context)", file=out)
+    print(inspection["catalogEntry"], file=out)
+
+    print(f"\nbody  (~{tokens['body']} tokens, loaded on demand)", file=out)
+    print(inspection["body"], file=out)

--- a/packages/cli/agentskills-cli/agentskills_cli/lint.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/lint.py
@@ -1,0 +1,141 @@
+"""``agentskills lint`` — quality warnings that are not spec violations.
+
+Everything here is legal per the specification and still likely to cost
+the author something: a description too long to sit comfortably in a
+catalog, a body that eats the context window, a script nobody is told
+to run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentskills_cli.discovery import SkillLocation
+from agentskills_cli.findings import WARNING, Finding, SkillReport
+from agentskills_cli.validate import check_frontmatter, read_skill_md, unreadable
+from agentskills_core import RESOURCE_KINDS, Skill, get_logger
+from agentskills_fs import LocalFileSystemSkillProvider
+
+# Every catalog entry is injected into the system prompt on every turn,
+# so a description is charged for far more often than a body is.
+CATALOG_DESCRIPTION_CHARS = 500
+
+DEFAULT_BODY_TOKEN_BUDGET = 5000
+
+# Rough enough to flag an outlier, and honest about being rough: a real
+# count needs the tokenizer of whichever model is being targeted.
+_CHARS_PER_TOKEN = 4
+
+_logger = get_logger(__name__)
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate the token cost of *text* at four characters per token."""
+    return -(-len(text) // _CHARS_PER_TOKEN)
+
+
+async def lint_location(
+    root: Path,
+    location: SkillLocation,
+    *,
+    body_token_budget: int = DEFAULT_BODY_TOKEN_BUDGET,
+) -> SkillReport:
+    """Lint one skill and return its report.
+
+    Args:
+        root: Provider root the skill lives under.
+        location: The skill to lint.
+        body_token_budget: Estimated token count above which the body is
+            reported as oversized.
+
+    Returns:
+        A report whose findings are warnings, unless the skill could not
+        be parsed at all — an unreadable or malformed skill is reported
+        as an error, because linting it would mean guessing.
+    """
+    try:
+        text = read_skill_md(location.path)
+    except (OSError, ValueError) as exc:
+        return SkillReport(location.skill_id, location.path, [unreadable(exc)])
+
+    blocking = check_frontmatter(text)
+    if blocking:
+        return SkillReport(location.skill_id, location.path, blocking)
+
+    skill = Skill(location.skill_id, LocalFileSystemSkillProvider(root))
+    metadata = await skill.get_metadata()
+    body = await skill.get_body()
+
+    findings: list[Finding] = []
+
+    if not metadata.get("version"):
+        findings.append(
+            Finding(
+                WARNING,
+                "missing-version",
+                "no 'version' field, so consumers cannot pin this skill or detect drift",
+            )
+        )
+
+    description = metadata.get("description")
+    if isinstance(description, str) and len(description) > CATALOG_DESCRIPTION_CHARS:
+        findings.append(
+            Finding(
+                WARNING,
+                "description-too-long-for-catalog",
+                f"description is {len(description)} characters; "
+                f"catalog entries stay in context every turn, so keep it under "
+                f"{CATALOG_DESCRIPTION_CHARS}",
+            )
+        )
+
+    tokens = estimate_tokens(body)
+    if tokens > body_token_budget:
+        findings.append(
+            Finding(
+                WARNING,
+                "body-over-token-budget",
+                f"body is roughly {tokens} tokens, over the {body_token_budget} budget; "
+                f"move detail into references/ so it loads only when needed",
+            )
+        )
+
+    findings.extend(await _unreferenced_resources(skill, body))
+
+    _logger.debug("Linted %s: %d findings", location.skill_id, len(findings))
+    return SkillReport(location.skill_id, location.path, findings)
+
+
+async def _unreferenced_resources(skill: Skill, body: str) -> list[Finding]:
+    """Warn about resource files the body never mentions.
+
+    An agent only reaches a reference, script, or asset if the body
+    tells it to, so a file nobody names is a file nobody loads.
+    """
+    if not skill.supports_resource_listing:
+        return []
+
+    resources = await skill.list_resources()
+    return [
+        Finding(
+            WARNING,
+            "unreferenced-resource",
+            f"{kind}/{name} is never mentioned in the body, so an agent will not know to load it",
+        )
+        for kind in RESOURCE_KINDS
+        for name in resources.get(kind, [])
+        if name not in body
+    ]
+
+
+async def lint_locations(
+    root: Path,
+    locations: list[SkillLocation],
+    *,
+    body_token_budget: int = DEFAULT_BODY_TOKEN_BUDGET,
+) -> list[SkillReport]:
+    """Lint every discovered skill, in ID order."""
+    return [
+        await lint_location(root, location, body_token_budget=body_token_budget)
+        for location in locations
+    ]

--- a/packages/cli/agentskills-cli/agentskills_cli/render.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/render.py
@@ -1,0 +1,104 @@
+"""Rendering — one human format and one JSON schema for every command.
+
+The JSON shape is a published contract: the validation GitHub Action
+and anything else in CI keys off it.  ``SCHEMA_VERSION`` is bumped only
+for a breaking change, and new fields are added rather than existing
+ones repurposed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, TextIO
+
+from agentskills_cli.discovery import relative_to_cwd
+from agentskills_cli.findings import SkillReport
+
+SCHEMA_VERSION = 1
+
+
+def count(reports: list[SkillReport]) -> tuple[int, int]:
+    """Return ``(errors, warnings)`` totalled across *reports*."""
+    errors = sum(len(report.errors) for report in reports)
+    warnings = sum(len(report.warnings) for report in reports)
+    return errors, warnings
+
+
+def exit_code(reports: list[SkillReport], *, strict: bool = False) -> int:
+    """Return the process exit code for *reports*.
+
+    Errors always fail.  Warnings fail only under *strict*, which is
+    what a repository sets when it wants lint findings to gate a pull
+    request.
+    """
+    errors, warnings = count(reports)
+    if errors or (strict and warnings):
+        return 1
+    return 0
+
+
+def plural(n: int, noun: str) -> str:
+    """Return *n* and *noun*, pluralised by adding an ``s``."""
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"
+
+
+def render_text(reports: list[SkillReport], out: TextIO) -> None:
+    """Write a human-readable report."""
+    for report in reports:
+        print(relative_to_cwd(report.path), file=out)
+        if not report.findings:
+            print("  ok", file=out)
+            continue
+        for finding in report.findings:
+            location = f" (line {finding.line})" if finding.line is not None else ""
+            print(
+                f"  {finding.severity:<7} {finding.code}{location}: {finding.message}",
+                file=out,
+            )
+
+    errors, warnings = count(reports)
+    print(
+        f"\n{plural(len(reports), 'skill')} checked, "
+        f"{plural(errors, 'error')}, {plural(warnings, 'warning')}",
+        file=out,
+    )
+
+
+def render_json(
+    command: str,
+    reports: list[SkillReport],
+    out: TextIO,
+    *,
+    strict: bool = False,
+) -> None:
+    """Write the machine-readable report.
+
+    ``ok`` mirrors the exit code, so a consumer never has to re-derive
+    the strictness rules to know whether the run passed.
+    """
+    errors, warnings = count(reports)
+    payload: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "command": command,
+        "ok": exit_code(reports, strict=strict) == 0,
+        "summary": {"skills": len(reports), "errors": errors, "warnings": warnings},
+        "skills": [
+            {
+                "id": report.skill_id,
+                "path": relative_to_cwd(report.path),
+                "ok": report.ok,
+                "findings": [
+                    {
+                        "severity": finding.severity,
+                        "code": finding.code,
+                        "message": finding.message,
+                        "line": finding.line,
+                    }
+                    for finding in report.findings
+                ],
+            }
+            for report in reports
+        ],
+    }
+    json.dump(payload, out, indent=2)
+    print(file=out)

--- a/packages/cli/agentskills-cli/agentskills_cli/scaffold.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/scaffold.py
@@ -1,0 +1,125 @@
+"""``agentskills init`` — scaffold a skill that already validates.
+
+The template is checked against :func:`~agentskills_core.validate_skill`
+before anything is written to disk.  That both rejects a bad skill name
+without duplicating the specification's rules here, and guarantees the
+template we ship cannot itself drift out of conformance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agentskills_cli.discovery import SKILL_FILE, CliError
+from agentskills_core import (
+    ResourceNotFoundError,
+    Skill,
+    SkillProvider,
+    get_logger,
+    validate_skill,
+)
+
+RESOURCE_DIRS = ("references", "scripts", "assets")
+
+DEFAULT_DESCRIPTION = "One sentence on what this skill does and when an agent should reach for it."
+
+_FRONTMATTER = """---
+name: {name}
+description: {description}
+version: 0.1.0
+---
+
+"""
+
+_BODY = """# {title}
+
+## When to use this
+
+Describe the situation that should make an agent load this skill.
+
+## Steps
+
+1. First step.
+2. Second step.
+
+## References
+
+Point at files in `references/` so they load only when they are needed.
+"""
+
+_logger = get_logger(__name__)
+
+
+class _TemplateProvider(SkillProvider):
+    """Serves the unwritten template so it can be validated in memory."""
+
+    def __init__(self, metadata: dict[str, Any], body: str) -> None:
+        self._metadata = metadata
+        self._body = body
+
+    async def get_metadata(self, skill_id: str) -> dict[str, Any]:
+        return self._metadata
+
+    async def get_body(self, skill_id: str) -> str:
+        return self._body
+
+    async def get_script(self, skill_id: str, name: str) -> bytes:
+        raise ResourceNotFoundError(f"Template has no scripts: {name!r}")
+
+    async def get_asset(self, skill_id: str, name: str) -> bytes:
+        raise ResourceNotFoundError(f"Template has no assets: {name!r}")
+
+    async def get_reference(self, skill_id: str, name: str) -> bytes:
+        raise ResourceNotFoundError(f"Template has no references: {name!r}")
+
+
+def render_body(name: str) -> str:
+    """Return the markdown body for a new skill."""
+    return _BODY.format(title=name.replace("-", " ").title())
+
+
+def render_skill_md(name: str, description: str) -> str:
+    """Return the full ``SKILL.md`` text for a new skill."""
+    return _FRONTMATTER.format(name=name, description=description) + render_body(name)
+
+
+async def init_skill(name: str, parent: Path, description: str = DEFAULT_DESCRIPTION) -> Path:
+    """Create a new skill directory under *parent*.
+
+    Args:
+        name: Skill name, which is also the directory name.
+        parent: Directory to create the skill in.
+        description: Frontmatter description for the new skill.
+
+    Returns:
+        The path of the created skill directory.
+
+    Raises:
+        CliError: If the name would not validate, if the skill already
+            exists, or if the directory cannot be written.
+    """
+    if not name.strip():
+        raise CliError("skill name must not be empty")
+
+    body = render_body(name)
+    metadata = {"name": name, "description": description, "version": "0.1.0"}
+    errors = await validate_skill(Skill(name, _TemplateProvider(metadata, body)))
+    if errors:
+        prefix = f"Skill '{name}': "
+        detail = "; ".join(message.removeprefix(prefix) for message in errors)
+        raise CliError(f"cannot scaffold '{name}': {detail}")
+
+    target = parent.expanduser().resolve() / name
+    if (target / SKILL_FILE).exists():
+        raise CliError(f"{target / SKILL_FILE} already exists")
+
+    try:
+        for resource_dir in RESOURCE_DIRS:
+            (target / resource_dir).mkdir(parents=True, exist_ok=True)
+        (target / SKILL_FILE).write_text(render_skill_md(name, description), encoding="utf-8")
+    except OSError as exc:
+        raise CliError(f"cannot write to {target}: {exc}") from exc
+
+    _logger.info("Scaffolded skill %s at %s", name, target)
+    return target

--- a/packages/cli/agentskills-cli/agentskills_cli/serve.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/serve.py
@@ -1,0 +1,51 @@
+"""``agentskills serve`` — run the MCP server over a folder of skills.
+
+The MCP server is an optional extra.  Importing it lazily keeps
+``agentskills validate`` — the command CI runs — free of ``mcp`` and
+``pydantic``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agentskills_cli.discovery import CliError, SkillLocation
+from agentskills_core import SkillRegistry, get_logger
+from agentskills_fs import LocalFileSystemSkillProvider
+
+_logger = get_logger(__name__)
+
+
+async def build_registry(root: Path, locations: list[SkillLocation]) -> SkillRegistry:
+    """Register every discovered skill against one filesystem provider.
+
+    Raises:
+        CliError: If a skill fails validation.  Registration is atomic,
+            so one bad skill would otherwise fail the whole server with
+            a message that does not say which command diagnoses it.
+    """
+    provider = LocalFileSystemSkillProvider(root)
+    registry = SkillRegistry()
+    try:
+        await registry.register([(location.skill_id, provider) for location in locations])
+    except ValueError as exc:
+        raise CliError(f"cannot serve: {exc}\nRun `agentskills validate` for details.") from exc
+    _logger.info("Registered %d skills from %s", len(locations), root)
+    return registry
+
+
+def create_server(registry: SkillRegistry, *, name: str) -> Any:
+    """Build the MCP server, or explain how to install it.
+
+    Raises:
+        CliError: If the ``serve`` extra is not installed.
+    """
+    try:
+        from agentskills_mcp_server.server import create_mcp_server
+    except ImportError as exc:
+        raise CliError(
+            "`agentskills serve` needs the MCP server. "
+            "Install it with:  pip install 'agentskills-cli[serve]'"
+        ) from exc
+    return create_mcp_server(registry, name=name)

--- a/packages/cli/agentskills-cli/agentskills_cli/validate.py
+++ b/packages/cli/agentskills-cli/agentskills_cli/validate.py
@@ -1,0 +1,146 @@
+"""``agentskills validate`` — spec conformance, exit code as the contract.
+
+Diagnosis happens in two stages.  Frontmatter is parsed here first,
+because :func:`~agentskills_core.split_frontmatter` is deliberately
+forgiving — malformed YAML yields an empty mapping rather than an
+exception, which downstream reads as "no name, no description" and
+tells the author nothing about the colon they missed.  Only once the
+frontmatter parses is the skill handed to
+:func:`~agentskills_core.validate_skill`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from agentskills_cli.discovery import SKILL_FILE, SkillLocation
+from agentskills_cli.findings import ERROR, Finding, SkillReport
+from agentskills_core import Skill, get_logger, validate_skill
+from agentskills_core.parsing import MAX_FRONTMATTER_BYTES
+from agentskills_fs import LocalFileSystemSkillProvider
+
+_logger = get_logger(__name__)
+
+
+def _yaml_detail(exc: yaml.YAMLError) -> tuple[str, int | None]:
+    """Reduce a YAML error to a one-line reason and a ``SKILL.md`` line."""
+    problem = getattr(exc, "problem", None)
+    mark = getattr(exc, "problem_mark", None)
+    reason = problem or str(exc).splitlines()[0]
+    # The mark is relative to the block, whose first line is the one
+    # after the opening '---'.
+    line = mark.line + 1 if mark is not None else None
+    return reason, line
+
+
+def check_frontmatter(text: str) -> list[Finding]:
+    """Report why the frontmatter of *text* cannot be parsed, if it cannot.
+
+    Args:
+        text: Full contents of a ``SKILL.md``.
+
+    Returns:
+        Findings describing the first structural problem found, or an
+        empty list when the frontmatter is a well-formed mapping.
+    """
+    if not text.startswith("---"):
+        return [
+            Finding(
+                ERROR,
+                "frontmatter-missing",
+                f"{SKILL_FILE} must open with a '---' frontmatter delimiter",
+                line=1,
+            )
+        ]
+
+    end = text.find("---", 3)
+    if end == -1:
+        return [
+            Finding(
+                ERROR,
+                "frontmatter-unclosed",
+                "the frontmatter block is never closed with '---'",
+                line=1,
+            )
+        ]
+
+    block = text[3:end]
+    if len(block.strip().encode("utf-8", errors="replace")) > MAX_FRONTMATTER_BYTES:
+        return [
+            Finding(
+                ERROR,
+                "frontmatter-too-large",
+                f"frontmatter exceeds {MAX_FRONTMATTER_BYTES} bytes and will be ignored entirely",
+                line=1,
+            )
+        ]
+
+    try:
+        parsed = yaml.safe_load(block)
+    except yaml.YAMLError as exc:
+        reason, line = _yaml_detail(exc)
+        return [
+            Finding(
+                ERROR,
+                "frontmatter-invalid-yaml",
+                f"frontmatter is not valid YAML: {reason}",
+                line,
+            )
+        ]
+
+    if parsed is not None and not isinstance(parsed, dict):
+        return [
+            Finding(
+                ERROR,
+                "frontmatter-not-a-mapping",
+                f"frontmatter must be a mapping of fields, not {type(parsed).__name__}",
+                line=2,
+            )
+        ]
+
+    return []
+
+
+def read_skill_md(path: Path) -> str:
+    """Return the text of the ``SKILL.md`` in skill directory *path*.
+
+    Raises:
+        OSError: If the file is missing or unreadable.
+        ValueError: If it is not valid UTF-8.
+    """
+    return path.joinpath(SKILL_FILE).read_text(encoding="utf-8")
+
+
+def unreadable(exc: Exception) -> Finding:
+    """Wrap a failed :func:`read_skill_md` as a finding."""
+    return Finding(ERROR, "unreadable", f"cannot read {SKILL_FILE}: {exc}")
+
+
+async def validate_location(root: Path, location: SkillLocation) -> SkillReport:
+    """Validate one skill and return its report."""
+    try:
+        text = read_skill_md(location.path)
+    except (OSError, ValueError) as exc:
+        return SkillReport(location.skill_id, location.path, [unreadable(exc)])
+
+    findings = check_frontmatter(text)
+    if findings:
+        # Spec checks read through the same forgiving parser, so they
+        # would only restate the damage in less useful terms.
+        return SkillReport(location.skill_id, location.path, findings)
+
+    skill = Skill(location.skill_id, LocalFileSystemSkillProvider(root))
+    prefix = f"Skill '{location.skill_id}': "
+    findings = [
+        Finding(ERROR, "spec", message.removeprefix(prefix))
+        for message in await validate_skill(skill)
+    ]
+    _logger.debug("Validated %s: %d findings", location.skill_id, len(findings))
+    return SkillReport(location.skill_id, location.path, findings)
+
+
+async def validate_locations(root: Path, locations: list[SkillLocation]) -> list[SkillReport]:
+    """Validate every discovered skill, in ID order."""
+    return [await validate_location(root, location) for location in locations]

--- a/packages/cli/agentskills-cli/pyproject.toml
+++ b/packages/cli/agentskills-cli/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.poetry]
+name = "agentskills-cli"
+version = "0.3.0"
+description = "Command line tools for authoring and validating Agent Skills (https://agentskills.io)"
+license = "MIT"
+authors = ["Pratik Panda"]
+readme = "README.md"
+homepage = "https://agentskills.io"
+repository = "https://github.com/pratikxpanda/agentskills-sdk"
+packages = [{include = "agentskills_cli"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries",
+    "Environment :: Console",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+
+[tool.poetry.dependencies]
+python = ">=3.12,<4.0"
+agentskills-core = ">=0.3.0,<1.0"
+agentskills-fs = ">=0.3.0,<1.0"
+agentskills-mcp-server = {version = ">=0.3.0,<1.0", optional = true}
+
+[tool.poetry.extras]
+serve = ["agentskills-mcp-server"]
+
+[tool.poetry.scripts]
+agentskills = "agentskills_cli.__main__:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/cli/agentskills-cli/tests/conftest.py
+++ b/packages/cli/agentskills-cli/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures: skills on disk, written as text so tests can break them."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+VALID = """---
+name: {name}
+description: A skill for testing.
+version: 1.0.0
+---
+
+# Test
+
+Body text.
+"""
+
+
+@pytest.fixture
+def skills_root(tmp_path: Path) -> Path:
+    """An empty directory to write skill folders into."""
+    root = tmp_path / "skills"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def write_skill(skills_root: Path) -> Callable[..., Path]:
+    """Write a skill folder, defaulting to a valid ``SKILL.md``."""
+
+    def _write(name: str, text: str | None = None) -> Path:
+        path = skills_root / name
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "SKILL.md").write_text(text if text is not None else VALID.format(name=name))
+        return path
+
+    return _write

--- a/packages/cli/agentskills-cli/tests/test_cli.py
+++ b/packages/cli/agentskills-cli/tests/test_cli.py
@@ -1,0 +1,161 @@
+"""End-to-end tests for the ``agentskills`` command."""
+
+from __future__ import annotations
+
+import json
+import logging
+import runpy
+import sys
+
+import pytest
+
+from agentskills_cli.cli import main
+from agentskills_core import LOGGER_NAMESPACE
+
+
+class TestValidate:
+    def test_clean_run_exits_zero(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+
+        assert main(["validate", str(skills_root)]) == 0
+        assert "1 skill checked, 0 errors" in capsys.readouterr().out
+
+    def test_broken_skill_exits_one(self, write_skill, skills_root, capsys):
+        write_skill("alpha", "no frontmatter")
+
+        assert main(["validate", str(skills_root)]) == 1
+        assert "frontmatter-missing" in capsys.readouterr().out
+
+    def test_json_format(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+
+        main(["validate", str(skills_root), "--format", "json"])
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "validate"
+        assert payload["ok"] is True
+
+    def test_missing_path_exits_two(self, tmp_path, capsys):
+        assert main(["validate", str(tmp_path / "nope")]) == 2
+        assert "error: not a directory" in capsys.readouterr().err
+
+
+class TestLint:
+    def test_warnings_do_not_fail_by_default(self, write_skill, skills_root):
+        write_skill("alpha", "---\nname: alpha\ndescription: d\n---\n\nBody.")
+
+        assert main(["lint", str(skills_root)]) == 0
+
+    def test_strict_fails_on_warnings(self, write_skill, skills_root):
+        write_skill("alpha", "---\nname: alpha\ndescription: d\n---\n\nBody.")
+
+        assert main(["lint", str(skills_root), "--strict"]) == 1
+
+    def test_token_budget_is_configurable(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+
+        main(["lint", str(skills_root), "--max-body-tokens", "1"])
+
+        assert "body-over-token-budget" in capsys.readouterr().out
+
+    def test_json_format(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+
+        main(["lint", str(skills_root), "--format", "json"])
+
+        assert json.loads(capsys.readouterr().out)["command"] == "lint"
+
+
+class TestInit:
+    def test_scaffolds_and_reports_the_path(self, tmp_path, capsys):
+        assert main(["init", "alpha", "--path", str(tmp_path)]) == 0
+        assert (tmp_path / "alpha" / "SKILL.md").is_file()
+        assert "Created" in capsys.readouterr().out
+
+    def test_bad_name_exits_two(self, tmp_path, capsys):
+        assert main(["init", "Bad Name", "--path", str(tmp_path)]) == 2
+        assert "error: cannot scaffold" in capsys.readouterr().err
+
+
+class TestInspect:
+    def test_text_output(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+
+        assert main(["inspect", str(skills_root)]) == 0
+        assert "catalog entry" in capsys.readouterr().out
+
+    def test_separates_multiple_skills(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+        write_skill("beta")
+
+        main(["inspect", str(skills_root)])
+
+        assert "-" * 60 in capsys.readouterr().out
+
+    def test_json_output(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+
+        main(["inspect", str(skills_root), "--format", "json"])
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["command"] == "inspect"
+        assert payload["skills"][0]["id"] == "alpha"
+
+
+class TestServe:
+    def test_runs_the_server_with_the_requested_transport(
+        self, write_skill, skills_root, monkeypatch, capsys
+    ):
+        write_skill("alpha")
+        started: dict[str, str] = {}
+
+        class _FakeServer:
+            def run(self, transport: str) -> None:
+                started["transport"] = transport
+
+        monkeypatch.setattr(
+            "agentskills_cli.cli.create_server", lambda registry, name: _FakeServer()
+        )
+
+        assert main(["serve", str(skills_root), "--transport", "streamable-http"]) == 0
+        assert started == {"transport": "streamable-http"}
+        assert "Serving 1 skill " in capsys.readouterr().err
+
+    def test_invalid_skill_exits_two(self, write_skill, skills_root, capsys):
+        write_skill("alpha", "---\nname: alpha\n---\n\nbody")
+
+        assert main(["serve", str(skills_root)]) == 2
+        assert "cannot serve" in capsys.readouterr().err
+
+
+class TestVerbose:
+    def test_attaches_a_stderr_handler_to_the_sdk_namespace(self, write_skill, skills_root, capsys):
+        write_skill("alpha")
+        logger = logging.getLogger(LOGGER_NAMESPACE)
+        before = list(logger.handlers)
+
+        try:
+            main(["validate", str(skills_root), "-v"])
+            assert "agentskills.cli" in capsys.readouterr().err
+        finally:
+            logger.handlers = before
+            logger.setLevel(logging.NOTSET)
+
+
+class TestParser:
+    def test_a_command_is_required(self):
+        with pytest.raises(SystemExit):
+            main([])
+
+
+class TestModuleEntryPoint:
+    def test_python_m_agentskills_cli_exits_with_the_command_status(
+        self, write_skill, skills_root, monkeypatch
+    ):
+        write_skill("alpha", "no frontmatter")
+        monkeypatch.setattr(sys, "argv", ["agentskills", "validate", str(skills_root)])
+
+        with pytest.raises(SystemExit) as exit_info:
+            runpy.run_module("agentskills_cli", run_name="__main__")
+
+        assert exit_info.value.code == 1

--- a/packages/cli/agentskills-cli/tests/test_discovery.py
+++ b/packages/cli/agentskills-cli/tests/test_discovery.py
@@ -1,0 +1,60 @@
+"""Tests for skill discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentskills_cli.discovery import CliError, discover, relative_to_cwd
+
+
+class TestDiscover:
+    def test_single_skill_folder_roots_at_the_parent(self, write_skill, skills_root):
+        path = write_skill("alpha")
+
+        root, locations = discover(path)
+
+        assert root == skills_root.resolve()
+        assert [(loc.skill_id, loc.path) for loc in locations] == [("alpha", path.resolve())]
+
+    def test_collection_returns_every_child_with_a_skill_file(self, write_skill, skills_root):
+        write_skill("beta")
+        write_skill("alpha")
+        (skills_root / "not-a-skill").mkdir()
+        (skills_root / "loose.md").write_text("ignored")
+
+        root, locations = discover(skills_root)
+
+        assert root == skills_root.resolve()
+        assert [loc.skill_id for loc in locations] == ["alpha", "beta"]
+
+    def test_missing_path_is_a_cli_error(self, tmp_path: Path):
+        with pytest.raises(CliError, match="not a directory"):
+            discover(tmp_path / "nope")
+
+    def test_file_is_a_cli_error(self, tmp_path: Path):
+        target = tmp_path / "SKILL.md"
+        target.write_text("---\n---\n")
+
+        with pytest.raises(CliError, match="not a directory"):
+            discover(target)
+
+    def test_directory_without_skills_is_a_cli_error(self, skills_root):
+        with pytest.raises(CliError, match="no skills found"):
+            discover(skills_root)
+
+
+class TestRelativeToCwd:
+    def test_relative_when_below_the_working_directory(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        assert relative_to_cwd(tmp_path / "skills" / "alpha") == "skills/alpha"
+
+    def test_absolute_when_not_below_the_working_directory(self, tmp_path, monkeypatch):
+        here = tmp_path / "here"
+        here.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        monkeypatch.chdir(here)
+
+        assert relative_to_cwd(elsewhere) == elsewhere.as_posix()

--- a/packages/cli/agentskills-cli/tests/test_inspection.py
+++ b/packages/cli/agentskills-cli/tests/test_inspection.py
@@ -1,0 +1,64 @@
+"""Tests for ``agentskills inspect``."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from agentskills_cli.discovery import CliError, SkillLocation
+from agentskills_cli.inspection import inspect_location, render_inspection_text
+
+
+class TestInspectLocation:
+    async def test_reports_what_the_agent_would_receive(self, write_skill, skills_root):
+        path = write_skill("alpha")
+
+        inspection = await inspect_location(skills_root, SkillLocation("alpha", path))
+
+        assert inspection["id"] == "alpha"
+        assert inspection["metadata"]["name"] == "alpha"
+        assert "<name>alpha</name>" in inspection["catalogEntry"]
+        assert inspection["body"].startswith("# Test")
+        assert inspection["estimatedTokens"]["body"] > 0
+
+    async def test_lists_resources(self, write_skill, skills_root):
+        path = write_skill("alpha")
+        (path / "references").mkdir()
+        (path / "references" / "runbook.md").write_text("...")
+
+        inspection = await inspect_location(skills_root, SkillLocation("alpha", path))
+
+        assert inspection["resources"]["references"] == ["runbook.md"]
+
+    async def test_invalid_skill_cannot_be_inspected(self, write_skill, skills_root):
+        path = write_skill("alpha", "---\nname: alpha\n---\n\nbody")
+
+        with pytest.raises(CliError, match="does not validate"):
+            await inspect_location(skills_root, SkillLocation("alpha", path))
+
+
+class TestRenderInspectionText:
+    async def test_renders_every_section(self, write_skill, skills_root):
+        path = write_skill("alpha")
+        inspection = await inspect_location(skills_root, SkillLocation("alpha", path))
+        out = io.StringIO()
+
+        render_inspection_text(inspection, out)
+
+        text = out.getvalue()
+        assert "metadata" in text
+        assert "resources\n  none" in text
+        assert "catalog entry" in text
+        assert "body" in text
+
+    async def test_lists_resource_paths(self, write_skill, skills_root):
+        path = write_skill("alpha")
+        (path / "scripts").mkdir()
+        (path / "scripts" / "run.sh").write_text("...")
+        inspection = await inspect_location(skills_root, SkillLocation("alpha", path))
+        out = io.StringIO()
+
+        render_inspection_text(inspection, out)
+
+        assert "scripts/run.sh" in out.getvalue()

--- a/packages/cli/agentskills-cli/tests/test_lint.py
+++ b/packages/cli/agentskills-cli/tests/test_lint.py
@@ -1,0 +1,129 @@
+"""Tests for ``agentskills lint``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentskills_cli.discovery import SkillLocation
+from agentskills_cli.lint import (
+    CATALOG_DESCRIPTION_CHARS,
+    _unreferenced_resources,
+    estimate_tokens,
+    lint_location,
+    lint_locations,
+)
+from agentskills_core import ResourceNotFoundError, Skill, SkillProvider
+
+
+class _BareProvider(SkillProvider):
+    """A provider that cannot enumerate — the default capability."""
+
+    async def get_metadata(self, skill_id: str) -> dict[str, Any]:
+        return {}
+
+    async def get_body(self, skill_id: str) -> str:
+        return ""
+
+    async def get_script(self, skill_id: str, name: str) -> bytes:
+        raise ResourceNotFoundError(name)
+
+    async def get_asset(self, skill_id: str, name: str) -> bytes:
+        raise ResourceNotFoundError(name)
+
+    async def get_reference(self, skill_id: str, name: str) -> bytes:
+        raise ResourceNotFoundError(name)
+
+
+def _skill_md(*, description: str = "A skill.", version: str | None = "1.0.0", body: str) -> str:
+    lines = ["---", "name: alpha", f"description: {description}"]
+    if version is not None:
+        lines.append(f"version: {version}")
+    lines += ["---", "", body]
+    return "\n".join(lines)
+
+
+class TestEstimateTokens:
+    def test_rounds_up(self):
+        assert estimate_tokens("") == 0
+        assert estimate_tokens("a") == 1
+        assert estimate_tokens("a" * 8) == 2
+
+
+class TestLintLocation:
+    async def test_clean_skill_warns_about_nothing(self, write_skill, skills_root):
+        path = write_skill("alpha", _skill_md(body="Body."))
+
+        report = await lint_location(skills_root, SkillLocation("alpha", path))
+
+        assert report.findings == []
+
+    async def test_missing_version(self, write_skill, skills_root):
+        path = write_skill("alpha", _skill_md(version=None, body="Body."))
+
+        report = await lint_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["missing-version"]
+
+    async def test_description_too_long_for_a_catalog(self, write_skill, skills_root):
+        path = write_skill(
+            "alpha", _skill_md(description="d" * (CATALOG_DESCRIPTION_CHARS + 1), body="Body.")
+        )
+
+        report = await lint_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["description-too-long-for-catalog"]
+
+    async def test_body_over_the_token_budget(self, write_skill, skills_root):
+        path = write_skill("alpha", _skill_md(body="word " * 100))
+
+        report = await lint_location(
+            skills_root, SkillLocation("alpha", path), body_token_budget=10
+        )
+
+        assert [f.code for f in report.findings] == ["body-over-token-budget"]
+
+    async def test_unreferenced_resource(self, write_skill, skills_root):
+        path = write_skill("alpha", _skill_md(body="Run scripts/used.sh first."))
+        (path / "scripts").mkdir()
+        (path / "scripts" / "used.sh").write_text("#!/bin/sh\n")
+        (path / "scripts" / "orphan.sh").write_text("#!/bin/sh\n")
+
+        report = await lint_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["unreferenced-resource"]
+        assert "scripts/orphan.sh" in report.findings[0].message
+
+    async def test_malformed_skill_is_an_error_rather_than_a_guess(self, write_skill, skills_root):
+        path = write_skill("alpha", "no frontmatter")
+
+        report = await lint_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.severity for f in report.findings] == ["error"]
+
+    async def test_unreadable_skill_file(self, skills_root):
+        path = skills_root / "alpha"
+        (path / "SKILL.md").mkdir(parents=True)
+
+        report = await lint_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["unreadable"]
+
+
+class TestUnreferencedResources:
+    async def test_provider_that_cannot_enumerate_is_not_second_guessed(self):
+        skill = Skill("alpha", _BareProvider())
+
+        assert await _unreferenced_resources(skill, "body") == []
+
+
+class TestLintLocations:
+    async def test_lints_every_skill(self, write_skill, skills_root):
+        alpha = write_skill("alpha", _skill_md(version=None, body="Body."))
+        beta = write_skill("beta", _skill_md(body="Body.").replace("alpha", "beta"))
+
+        reports = await lint_locations(
+            skills_root,
+            [SkillLocation("alpha", alpha), SkillLocation("beta", beta)],
+        )
+
+        assert [len(r.findings) for r in reports] == [1, 0]

--- a/packages/cli/agentskills-cli/tests/test_render.py
+++ b/packages/cli/agentskills-cli/tests/test_render.py
@@ -1,0 +1,97 @@
+"""Tests for report rendering and exit codes."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from agentskills_cli.findings import ERROR, WARNING, Finding, SkillReport
+from agentskills_cli.render import count, exit_code, render_json, render_text
+
+
+def _report(*findings: Finding) -> SkillReport:
+    return SkillReport("alpha", Path("skills/alpha"), list(findings))
+
+
+ERROR_FINDING = Finding(ERROR, "spec", "body is empty", line=7)
+WARNING_FINDING = Finding(WARNING, "missing-version", "no version field")
+
+
+class TestCount:
+    def test_totals_across_reports(self):
+        assert count([_report(ERROR_FINDING), _report(WARNING_FINDING, WARNING_FINDING)]) == (1, 2)
+
+
+class TestExitCode:
+    def test_clean_run_passes(self):
+        assert exit_code([_report()]) == 0
+
+    def test_errors_always_fail(self):
+        assert exit_code([_report(ERROR_FINDING)]) == 1
+
+    def test_warnings_pass_by_default(self):
+        assert exit_code([_report(WARNING_FINDING)]) == 0
+
+    def test_warnings_fail_under_strict(self):
+        assert exit_code([_report(WARNING_FINDING)], strict=True) == 1
+
+
+class TestRenderText:
+    def test_clean_skill_is_marked_ok(self):
+        out = io.StringIO()
+
+        render_text([_report()], out)
+
+        assert "  ok" in out.getvalue()
+        assert "1 skill checked, 0 errors, 0 warnings" in out.getvalue()
+
+    def test_findings_carry_severity_code_and_line(self):
+        out = io.StringIO()
+
+        render_text([_report(ERROR_FINDING, WARNING_FINDING)], out)
+
+        text = out.getvalue()
+        assert "error   spec (line 7): body is empty" in text
+        assert "warning missing-version: no version field" in text
+        assert "1 skill checked, 1 error, 1 warning" in text
+
+
+class TestRenderJson:
+    def test_schema(self):
+        out = io.StringIO()
+
+        render_json("validate", [_report(ERROR_FINDING)], out)
+
+        payload = json.loads(out.getvalue())
+        assert payload == {
+            "schemaVersion": 1,
+            "command": "validate",
+            "ok": False,
+            "summary": {"skills": 1, "errors": 1, "warnings": 0},
+            "skills": [
+                {
+                    "id": "alpha",
+                    "path": "skills/alpha",
+                    "ok": False,
+                    "findings": [
+                        {
+                            "severity": "error",
+                            "code": "spec",
+                            "message": "body is empty",
+                            "line": 7,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    def test_ok_mirrors_the_exit_code_under_strict(self):
+        out = io.StringIO()
+
+        render_json("lint", [_report(WARNING_FINDING)], out, strict=True)
+
+        payload = json.loads(out.getvalue())
+        # The skill itself has no errors, but the run failed.
+        assert payload["ok"] is False
+        assert payload["skills"][0]["ok"] is True

--- a/packages/cli/agentskills-cli/tests/test_scaffold.py
+++ b/packages/cli/agentskills-cli/tests/test_scaffold.py
@@ -1,0 +1,73 @@
+"""Tests for ``agentskills init``."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentskills_cli.discovery import CliError
+from agentskills_cli.scaffold import RESOURCE_DIRS, _TemplateProvider, init_skill, render_skill_md
+from agentskills_core import ResourceNotFoundError
+
+
+class TestInitSkill:
+    async def test_creates_a_skill_that_validates(self, tmp_path):
+        from agentskills_cli.discovery import discover
+        from agentskills_cli.validate import validate_locations
+
+        target = await init_skill("incident-response", tmp_path)
+
+        assert (target / "SKILL.md").is_file()
+        assert all((target / d).is_dir() for d in RESOURCE_DIRS)
+        assert all(report.ok for report in await validate_locations(*discover(target)))
+
+    async def test_title_is_derived_from_the_name(self, tmp_path):
+        target = await init_skill("incident-response", tmp_path)
+
+        assert "# Incident Response" in (target / "SKILL.md").read_text()
+
+    async def test_custom_description_is_used(self, tmp_path):
+        target = await init_skill("alpha", tmp_path, "Describes the alpha process.")
+
+        assert "description: Describes the alpha process." in (target / "SKILL.md").read_text()
+
+    async def test_empty_name_is_refused(self, tmp_path):
+        with pytest.raises(CliError, match="must not be empty"):
+            await init_skill("   ", tmp_path)
+
+    async def test_name_is_checked_against_the_specification(self, tmp_path):
+        with pytest.raises(CliError, match="lowercase"):
+            await init_skill("Not Valid", tmp_path)
+
+        assert not (tmp_path / "Not Valid").exists()
+
+    async def test_existing_skill_is_not_overwritten(self, tmp_path):
+        await init_skill("alpha", tmp_path)
+
+        with pytest.raises(CliError, match="already exists"):
+            await init_skill("alpha", tmp_path)
+
+    async def test_unwritable_parent_is_a_cli_error(self, tmp_path):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+
+        with pytest.raises(CliError, match="cannot write"):
+            await init_skill("alpha", blocker)
+
+
+class TestTemplateProvider:
+    """The template has no resources; asking for one is an error, not empty bytes."""
+
+    async def test_resource_lookups_fail(self):
+        provider = _TemplateProvider({"name": "alpha"}, "body")
+
+        for lookup in (provider.get_script, provider.get_asset, provider.get_reference):
+            with pytest.raises(ResourceNotFoundError, match="Template has no"):
+                await lookup("alpha", "anything")
+
+
+class TestRenderSkillMd:
+    def test_frontmatter_precedes_the_body(self):
+        text = render_skill_md("alpha", "A skill.")
+
+        assert text.startswith("---\nname: alpha\ndescription: A skill.\nversion: 0.1.0\n---\n")
+        assert "# Alpha" in text

--- a/packages/cli/agentskills-cli/tests/test_serve.py
+++ b/packages/cli/agentskills-cli/tests/test_serve.py
@@ -1,0 +1,50 @@
+"""Tests for ``agentskills serve``."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from agentskills_cli.discovery import CliError, SkillLocation
+from agentskills_cli.serve import build_registry, create_server
+
+
+class TestBuildRegistry:
+    async def test_registers_every_skill(self, write_skill, skills_root):
+        alpha = write_skill("alpha")
+        beta = write_skill("beta")
+
+        registry = await build_registry(
+            skills_root, [SkillLocation("alpha", alpha), SkillLocation("beta", beta)]
+        )
+
+        assert [skill.get_id() for skill in registry.list_skills()] == ["alpha", "beta"]
+
+    async def test_invalid_skill_points_at_the_command_that_diagnoses_it(
+        self, write_skill, skills_root
+    ):
+        path = write_skill("alpha", "---\nname: alpha\n---\n\nbody")
+
+        with pytest.raises(CliError, match="agentskills validate"):
+            await build_registry(skills_root, [SkillLocation("alpha", path)])
+
+
+class TestCreateServer:
+    async def test_builds_a_server(self, write_skill, skills_root):
+        path = write_skill("alpha")
+        registry = await build_registry(skills_root, [SkillLocation("alpha", path)])
+
+        server = create_server(registry, name="Test")
+
+        assert server is not None
+
+    async def test_missing_extra_explains_how_to_install_it(
+        self, write_skill, skills_root, monkeypatch
+    ):
+        path = write_skill("alpha")
+        registry = await build_registry(skills_root, [SkillLocation("alpha", path)])
+        monkeypatch.setitem(sys.modules, "agentskills_mcp_server.server", None)
+
+        with pytest.raises(CliError, match=r"agentskills-cli\[serve\]"):
+            create_server(registry, name="Test")

--- a/packages/cli/agentskills-cli/tests/test_validate.py
+++ b/packages/cli/agentskills-cli/tests/test_validate.py
@@ -1,0 +1,107 @@
+"""Tests for ``agentskills validate``."""
+
+from __future__ import annotations
+
+import yaml
+
+from agentskills_cli.discovery import SkillLocation
+from agentskills_cli.validate import (
+    _yaml_detail,
+    check_frontmatter,
+    validate_location,
+    validate_locations,
+)
+
+
+class TestCheckFrontmatter:
+    def test_valid_frontmatter_has_no_findings(self):
+        assert check_frontmatter("---\nname: a\n---\n\nbody") == []
+
+    def test_empty_frontmatter_is_not_a_structural_problem(self):
+        # An empty mapping is well-formed; the spec checks catch it.
+        assert check_frontmatter("---\n---\n\nbody") == []
+
+    def test_missing_delimiter(self):
+        [finding] = check_frontmatter("# Just a heading\n")
+
+        assert finding.code == "frontmatter-missing"
+        assert finding.line == 1
+
+    def test_unclosed_block(self):
+        [finding] = check_frontmatter("---\nname: a\n")
+
+        assert finding.code == "frontmatter-unclosed"
+
+    def test_oversized_block_is_reported_rather_than_silently_ignored(self):
+        padding = "x" * (256 * 1024)
+        [finding] = check_frontmatter(f"---\nname: {padding}\n---\n\nbody")
+
+        assert finding.code == "frontmatter-too-large"
+
+    def test_invalid_yaml_reports_the_line(self):
+        [finding] = check_frontmatter("---\nname: a\n  description: b: c\n---\n\nbody")
+
+        assert finding.code == "frontmatter-invalid-yaml"
+        assert finding.line == 3
+
+    def test_sequence_instead_of_mapping(self):
+        [finding] = check_frontmatter("---\n- name\n- description\n---\n\nbody")
+
+        assert finding.code == "frontmatter-not-a-mapping"
+        assert "not list" in finding.message
+
+
+class TestYamlDetail:
+    def test_falls_back_to_the_message_when_there_is_no_mark(self):
+        reason, line = _yaml_detail(yaml.YAMLError("something went wrong"))
+
+        assert reason == "something went wrong"
+        assert line is None
+
+
+class TestValidateLocation:
+    async def test_valid_skill_reports_nothing(self, write_skill, skills_root):
+        path = write_skill("alpha")
+
+        report = await validate_location(skills_root, SkillLocation("alpha", path))
+
+        assert report.findings == []
+        assert report.ok
+
+    async def test_spec_errors_are_reported_without_the_redundant_prefix(
+        self, write_skill, skills_root
+    ):
+        path = write_skill("alpha", "---\nname: not-alpha\ndescription: d\n---\n\nbody")
+
+        report = await validate_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["spec"]
+        assert report.findings[0].message.startswith("metadata name")
+
+    async def test_frontmatter_failure_suppresses_the_spec_checks(self, write_skill, skills_root):
+        path = write_skill("alpha", "no frontmatter here")
+
+        report = await validate_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["frontmatter-missing"]
+
+    async def test_unreadable_skill_file(self, skills_root):
+        path = skills_root / "alpha"
+        (path / "SKILL.md").mkdir(parents=True)
+
+        report = await validate_location(skills_root, SkillLocation("alpha", path))
+
+        assert [f.code for f in report.findings] == ["unreadable"]
+
+
+class TestValidateLocations:
+    async def test_reports_every_skill(self, write_skill, skills_root):
+        alpha = write_skill("alpha")
+        beta = write_skill("beta", "broken")
+
+        reports = await validate_locations(
+            skills_root,
+            [SkillLocation("alpha", alpha), SkillLocation("beta", beta)],
+        )
+
+        assert [r.ok for r in reports] == [True, False]

--- a/poetry.lock
+++ b/poetry.lock
@@ -40,6 +40,27 @@ type = "directory"
 url = "packages/integrations/agentskills-agentframework"
 
 [[package]]
+name = "agentskills-cli"
+version = "0.3.0"
+description = "Command line tools for authoring and validating Agent Skills (https://agentskills.io)"
+optional = false
+python-versions = ">=3.12,<4.0"
+groups = ["main"]
+files = []
+develop = true
+
+[package.dependencies]
+agentskills-core = ">=0.3.0,<1.0"
+agentskills-fs = ">=0.3.0,<1.0"
+
+[package.extras]
+serve = ["agentskills-mcp-server (>=0.3.0,<1.0)"]
+
+[package.source]
+type = "directory"
+url = "packages/cli/agentskills-cli"
+
+[[package]]
 name = "agentskills-core"
 version = "0.3.0"
 description = "Storage-agnostic abstractions for discovering, validating, and accessing Agent Skills (https://agentskills.io)"
@@ -2685,4 +2706,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "0f0f859e4ff332bcc171bf69cead97b6b3ec127f0d05c5b02b7194ddbd0ed37e"
+content-hash = "1139af54e9e5f294a4bce03d4633e20747e2de0402c69233da03022c05171883"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ agentskills-http = { path = "packages/providers/agentskills-http", develop = tru
 agentskills-langchain = { path = "packages/integrations/agentskills-langchain", develop = true }
 agentskills-agentframework = { path = "packages/integrations/agentskills-agentframework", develop = true }
 agentskills-mcp-server = { path = "packages/integrations/agentskills-mcp-server", develop = true }
+agentskills-cli = { path = "packages/cli/agentskills-cli", develop = true }
 pyjwt = ">=2.12.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -43,6 +44,7 @@ source_pkgs = [
     "agentskills_langchain",
     "agentskills_agentframework",
     "agentskills_mcp_server",
+    "agentskills_cli",
 ]
 
 [tool.coverage.report]
@@ -75,4 +77,4 @@ select = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["agentskills_core", "agentskills_fs", "agentskills_http", "agentskills_langchain", "agentskills_agentframework", "agentskills_mcp_server"]
+known-first-party = ["agentskills_core", "agentskills_fs", "agentskills_http", "agentskills_langchain", "agentskills_agentframework", "agentskills_mcp_server", "agentskills_cli"]

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -43,7 +43,8 @@ $pyprojectFiles = @(
     "packages/providers/agentskills-http/pyproject.toml",
     "packages/integrations/agentskills-langchain/pyproject.toml",
     "packages/integrations/agentskills-agentframework/pyproject.toml",
-    "packages/integrations/agentskills-mcp-server/pyproject.toml"
+    "packages/integrations/agentskills-mcp-server/pyproject.toml",
+    "packages/cli/agentskills-cli/pyproject.toml"
 )
 
 # Read current version from root pyproject.toml
@@ -98,7 +99,7 @@ foreach ($relPath in $pyprojectFiles) {
 
     $content = Get-Content $filePath -Raw
     $updated = $content -replace "version = `"$currentVersion`"", "version = `"$newVersion`""
-    # The six ship in lockstep, so a dependent must require the core it ships with.
+    # These ship in lockstep, so a dependent must require the core it ships with.
     $updated = $updated -replace 'agentskills-core = "[^"]*"', "agentskills-core = `">=$newVersion,<1.0`""
     Set-Content -Path $filePath -Value $updated -NoNewline
     Write-Host "  Updated $relPath" -ForegroundColor Green

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -21,6 +21,7 @@ PYPROJECT_FILES=(
     "packages/integrations/agentskills-langchain/pyproject.toml"
     "packages/integrations/agentskills-agentframework/pyproject.toml"
     "packages/integrations/agentskills-mcp-server/pyproject.toml"
+    "packages/cli/agentskills-cli/pyproject.toml"
 )
 
 BUMP="patch"
@@ -85,7 +86,7 @@ if $DRY_RUN; then
 else
     for rel_path in "${PYPROJECT_FILES[@]}"; do
         file_path="$REPO_ROOT/$rel_path"
-        # The six ship in lockstep, so a dependent must require the core it ships with.
+        # These ship in lockstep, so a dependent must require the core it ships with.
         sed_args=(
             -e "s/version = \"$current_version\"/version = \"$new_version\"/"
             -e "s/agentskills-core = \"[^\"]*\"/agentskills-core = \">=$new_version,<1.0\"/"

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -2,7 +2,7 @@
 
 Run before tagging a release::
 
-    python scripts/check_release_version.py            # the six packages agree
+    python scripts/check_release_version.py            # every package agrees
     python scripts/check_release_version.py --tag v0.3.0   # ...and match the tag
 
 The tag must be ``v`` followed by the exact version string, so ``0.3.0rc1`` is
@@ -27,6 +27,7 @@ DEPENDENTS = [
     "packages/integrations/agentskills-langchain",
     "packages/integrations/agentskills-agentframework",
     "packages/integrations/agentskills-mcp-server",
+    "packages/cli/agentskills-cli",
 ]
 
 PACKAGES = [CORE, *DEPENDENTS]
@@ -65,7 +66,7 @@ def _check_versions(tag: str | None) -> tuple[str | None, list[str]]:
 def _check_core_floor(version: str) -> list[str]:
     """Dependents must require the core they are released with.
 
-    The six ship in lockstep, so a floor below the release version lets pip
+    They ship in lockstep, so a floor below the release version lets pip
     resolve an older core against a newer dependent and fail at import.
     """
     expected = f">={version},<1.0"
@@ -96,7 +97,10 @@ def main() -> int:
             print(f"  - {error}", file=sys.stderr)
         return 1
 
-    print(f"\nOK: all six packages at {version}" + (f", matching {args.tag}" if args.tag else ""))
+    print(
+        f"\nOK: all {len(PACKAGES)} packages at {version}"
+        + (f", matching {args.tag}" if args.tag else "")
+    )
     return 0
 
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -34,6 +34,7 @@ COVERAGE_FLOORS: dict[str, int] = {
     "agentskills_langchain": 100,
     "agentskills_agentframework": 100,
     "agentskills_mcp_server": 91,
+    "agentskills_cli": 99,
 }
 
 


### PR DESCRIPTION
Adds a seventh package, agentskills-cli, providing init, validate, lint, inspect and serve. Validation reports frontmatter problems with line numbers, which the forgiving parser in core deliberately swallows, so an author saw a skill silently load with no metadata rather than an error pointing at the bad line.

The package depends only on agentskills-core and agentskills-fs and uses stdlib argparse; serve is behind a [serve] extra so a CI job that only validates does not install mcp and pydantic. Exit codes separate findings (1) from failure to look (2).

Also wires the package into all seven registration points and updates the docs that hardcoded a package count of six.