### PR TITLE
chore: repair the mangled version comments on the CodeQL pins

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,6 +95,10 @@ that task fails for reasons unrelated to your change.
   not in the job.
 - **Dependency ceilings need evidence.** Check the dependency's real `requires_python` and
   classifiers on PyPI before adding or trusting an upper bound.
+- **Dependabot mangles the version comment on action pins.** `# v4.37.4.4.37.42.4.37.4` has
+  appeared twice. The SHA is right and the comment is not, so read it as decoration and
+  confirm with `git ls-remote --tags <repo> 'refs/tags/vX.Y.Z^{}'` — annotated tags, which
+  `github/codeql-action` uses, need the `^{}` or you compare against the tag object.
 - **A 200 response does not mean a badge rendered.** shields.io returns 200 with the words
   "rate limited by upstream service" drawn into the SVG. Inspect the rendered text.
 - **An optional provider capability is a flag plus a raising default**, never an empty

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4.4.37.42.4.37.4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4.4.37.42.4.37.4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
Dependabot wrote '# v4.37.4.4.37.42.4.37.4' on both codeql-action pins. The SHA is correct -- f205ea1 is refs/tags/v4.37.4^{}, confirmed against the remote -- so this is comment-only, but the comment is the only human-readable record of what the pin is.

Noted in the instructions, along with the '^{}' dereference that codeql-action's annotated tags require.