### PR TITLE
fix: declare pyyaml in the CLI, and check the whole class

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,7 @@ poetry install                                    # after any pyproject change, 
 python -m pytest packages -q --no-header          # baseline: 1131 passed, 7 skipped
 python -m ruff check packages/ examples/       # CI lints these two paths only
 python -m ruff format --check packages/ examples/
+python scripts/check_declared_dependencies.py     # a package must declare what it imports
 ```
 
 `scripts/dev.py check` also runs a `mypy` step, but `mypy` is not currently installed —
@@ -82,6 +83,12 @@ that task fails for reasons unrelated to your change.
   known-first-party`), `scripts/dev.py` `COVERAGE_FLOORS`, both `bump-version` scripts,
   `scripts/check_release_version.py`, and the build loop plus a publish step in
   `.github/workflows/publish.yml`. Miss the last one and the package silently never ships.
+  `scripts/check_declared_dependencies.py` has its own list too, so eight.
+- **A package can import what it never declared and nothing will notice**, because every
+  package is installed into one shared virtualenv here. `agentskills-cli` imported `yaml`
+  without declaring `pyyaml` for a whole milestone, riding on the copy `agentskills-core`
+  pulled in. `scripts/check_declared_dependencies.py` runs in the lint job now; an import
+  meant to stay optional belongs inside a function or behind `except ImportError`.
 - **A package with a `pytest11` entry point is invisible to `pytest --cov`.** Entry-point
   plugins are imported before pytest-cov starts measuring, so the package reports 0% and
   drags everything it imports down with it. `scripts/dev.py test:cov` runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Lint
         run: poetry run ruff check packages/ examples/
 
+      # Every package shares one virtualenv here, so a missing declaration is
+      # invisible until somebody installs a single package from PyPI.
+      - name: Check declared dependencies
+        run: poetry run python scripts/check_declared_dependencies.py
+
       - name: Audit dependencies
         run: poetry run pip-audit
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,7 +98,8 @@ python scripts/dev.py lint:fix      # Auto-fix lint issues
 python scripts/dev.py format        # Auto-format code
 python scripts/dev.py format:check  # Check formatting without changes
 python scripts/dev.py typecheck     # Run mypy type checking
-python scripts/dev.py check         # Lint + format check + type check
+python scripts/dev.py deps          # Check every package declares what it imports
+python scripts/dev.py check         # Lint + format check + type check + deps
 python scripts/dev.py test          # Run all tests
 python scripts/dev.py test:cov      # Run tests with coverage
 python scripts/dev.py clean         # Remove cache files
@@ -109,7 +110,7 @@ python scripts/dev.py all           # Format + lint + test
 
 GitHub Actions runs automatically on every push and pull request to `main`. The pipeline is defined in `.github/workflows/ci.yml` and includes these jobs:
 
-- **Lint**: checks formatting (`ruff format --check`) and linting (`ruff check`)
+- **Lint**: checks formatting (`ruff format --check`), linting (`ruff check`), and that every package declares the third-party modules it imports
 - **Test**: runs `pytest` across Python 3.12, 3.13, and 3.14
 - **Coverage**: runs the coverage gate and publishes the report to the job summary
 - **Test (latest permitted dependencies)**: resolves without `poetry.lock` to surface upstream breakage; advisory only
@@ -133,6 +134,23 @@ python scripts/dev.py typecheck
 ```
 
 Type annotations are expected on all public functions and methods.
+
+## Dependency Declarations
+
+Every package here is installed into one shared virtualenv alongside its siblings, so a package
+can import a module it never declared and nothing will notice. The failure only appears for
+somebody who installed that one package from PyPI, and it appears as an `ImportError` on their
+first command. `agentskills-cli` shipped that way for a whole milestone, riding on the `pyyaml`
+that `agentskills-core` pulled in.
+
+```bash
+python scripts/check_declared_dependencies.py
+```
+
+It compares the module-level imports in each package's source against its declared dependencies.
+Imports nested in a function or guarded by `except ImportError` are ignored, because that is the
+pattern for an optional capability — `tiktoken` in the CLI, `agent_framework` in the MCP server —
+and declaring those would defeat the point of making them optional.
 
 ## Logging Conventions
 

--- a/packages/cli/agentskills-cli/pyproject.toml
+++ b/packages/cli/agentskills-cli/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 python = ">=3.12,<4.0"
 agentskills-core = ">=0.3.0,<1.0"
 agentskills-fs = ">=0.3.0,<1.0"
+pyyaml = ">=6.0,<7.0"
 agentskills-mcp-server = {version = ">=0.3.0,<1.0", optional = true}
 
 [tool.poetry.extras]

--- a/packages/testing/agentskills-testing/pyproject.toml
+++ b/packages/testing/agentskills-testing/pyproject.toml
@@ -24,7 +24,7 @@ python = ">=3.12,<4.0"
 agentskills-core = ">=0.3.0,<1.0"
 pytest = ">=8.0"
 pytest-asyncio = ">=0.24"
-pyyaml = ">=6.0"
+pyyaml = ">=6.0,<7.0"
 
 [tool.poetry.plugins.pytest11]
 agentskills_testing = "agentskills_testing.fixtures"

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,6 +52,7 @@ develop = true
 [package.dependencies]
 agentskills-core = ">=0.3.0,<1.0"
 agentskills-fs = ">=0.3.0,<1.0"
+pyyaml = ">=6.0,<7.0"
 
 [package.extras]
 serve = ["agentskills-mcp-server (>=0.3.0,<1.0)"]
@@ -170,7 +171,7 @@ develop = true
 agentskills-core = ">=0.3.0,<1.0"
 pytest = ">=8.0"
 pytest-asyncio = ">=0.24"
-pyyaml = ">=6.0"
+pyyaml = ">=6.0,<7.0"
 
 [package.source]
 type = "directory"

--- a/scripts/check_declared_dependencies.py
+++ b/scripts/check_declared_dependencies.py
@@ -1,0 +1,159 @@
+"""Check that every package declares the third-party modules it imports.
+
+Run it like the other release checks::
+
+    python scripts/check_declared_dependencies.py
+
+A missing declaration is invisible in this repo, because every package is
+installed into one shared virtualenv alongside its siblings. It only appears
+for somebody who installed a single package from PyPI, and it appears as an
+ImportError on their first command. ``agentskills-cli`` shipped that way for a
+whole milestone: it imports ``yaml`` and never declared ``pyyaml``, riding on
+the copy that ``agentskills-core`` pulled in.
+
+Only module-level imports count. An import nested in a function or guarded by
+``except ImportError`` is an optional capability, which is exactly the pattern
+used for tokenizers and for cross-integration bridges, and declaring those
+would defeat the point of making them optional.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+import tomllib
+from importlib.metadata import packages_distributions
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+PACKAGES = [
+    "packages/core/agentskills-core",
+    "packages/providers/agentskills-fs",
+    "packages/providers/agentskills-http",
+    "packages/integrations/agentskills-langchain",
+    "packages/integrations/agentskills-agentframework",
+    "packages/integrations/agentskills-mcp-server",
+    "packages/cli/agentskills-cli",
+    "packages/testing/agentskills-testing",
+]
+
+OPTIONAL_ERRORS = {"ImportError", "ModuleNotFoundError"}
+
+
+def _normalise(name: str) -> str:
+    """PEP 503 name comparison, so pyyaml and PyYAML are one dependency."""
+    out = []
+    previous_separator = False
+    for char in name.lower():
+        if char in "-_.":
+            if not previous_separator:
+                out.append("-")
+            previous_separator = True
+        else:
+            out.append(char)
+            previous_separator = False
+    return "".join(out)
+
+
+def _guards_import(node: ast.Try) -> bool:
+    for handler in node.handlers:
+        caught = handler.type
+        if isinstance(caught, ast.Tuple):
+            names = {name.id for name in caught.elts if isinstance(name, ast.Name)}
+        elif isinstance(caught, ast.Name):
+            names = {caught.id}
+        else:
+            continue
+        if names & OPTIONAL_ERRORS:
+            return True
+    return False
+
+
+def _required_imports(body: list[ast.stmt]) -> set[str]:
+    """Top-level module names imported unconditionally.
+
+    Descends into ``if`` and unguarded ``try`` blocks — a ``TYPE_CHECKING``
+    import still names a package the type checker has to find — but stops at
+    a function or class, and at any ``try`` that catches an import failure.
+    """
+    modules: set[str] = set()
+    for node in body:
+        if isinstance(node, ast.Import):
+            modules |= {alias.name.split(".")[0] for alias in node.names}
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                modules.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Try):
+            if not _guards_import(node):
+                modules |= _required_imports(node.body)
+        elif isinstance(node, ast.If):
+            modules |= _required_imports(node.body) | _required_imports(node.orelse)
+    return modules
+
+
+def _source_imports(package: Path) -> set[str]:
+    modules: set[str] = set()
+    for path in sorted(package.rglob("agentskills_*/**/*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        modules |= _required_imports(tree.body)
+    return modules
+
+
+def _distributions_for(module: str, index: dict[str, list[str]]) -> set[str]:
+    """Which distribution ships this module, normalised.
+
+    Falls back to the module name itself, which is right often enough to give
+    a usable error message when the module is not installed here at all.
+    """
+    return {_normalise(name) for name in index.get(module, [module])}
+
+
+def _declared(package: Path) -> set[str]:
+    manifest = tomllib.loads((package / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = manifest["tool"]["poetry"]["dependencies"]
+    return {_normalise(name) for name in dependencies if name != "python"}
+
+
+def _check(package: str, index: dict[str, list[str]]) -> list[str]:
+    path = ROOT / package
+    declared = _declared(path)
+    stdlib = sys.stdlib_module_names
+
+    missing = []
+    for module in sorted(_source_imports(path)):
+        if module in stdlib or module == path.name.replace("-", "_"):
+            continue
+        candidates = _distributions_for(module, index)
+        if not candidates & declared:
+            missing.append(f"{module} (from {', '.join(sorted(candidates))})")
+
+    print(f"  {path.name:<32} {len(declared)} declared, {len(missing)} missing")
+    return [
+        f"{path.name} imports {module} without declaring it in pyproject.toml."
+        for module in missing
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    index = packages_distributions()
+    errors: list[str] = []
+    for package in PACKAGES:
+        errors += _check(package, index)
+
+    if errors:
+        print("\nERROR:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"\nOK: all {len(PACKAGES)} packages declare what they import")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -80,11 +80,17 @@ def typecheck() -> None:
     _run([_PY, "-m", "mypy", "packages/"], check=False)
 
 
+def deps() -> None:
+    """Check that every package declares the third-party modules it imports."""
+    _run([_PY, "scripts/check_declared_dependencies.py"])
+
+
 def check() -> None:
-    """Run all checks (format check + lint + type check) without modifying files."""
+    """Run all checks (format check + lint + type check + deps) without modifying files."""
     fmt_check()
     lint()
     typecheck()
+    deps()
 
 
 def test() -> None:
@@ -192,6 +198,7 @@ TASKS = {
     "fmt": fmt,
     "format:check": fmt_check,
     "typecheck": typecheck,
+    "deps": deps,
     "check": check,
     "test": test,
     "test:cov": test_cov,


### PR DESCRIPTION
agentskills-cli imports yaml and never declared pyyaml. Nothing caught it because every package in this repo is installed into one shared virtualenv, so the copy agentskills-core pulls in satisfies the import. It would have failed for the first person to pip install agentskills-cli on its own, as an ImportError on their first command.

scripts/check_declared_dependencies.py compares the module-level imports in each package's source against its declared dependencies, and runs in the lint job. Imports nested in a function or guarded by except ImportError are ignored: that is the pattern for an optional capability, tiktoken in the CLI and agent_framework in the MCP server, and declaring those would defeat the point.

Also tightened agentskills-testing's pyyaml constraint to match core and the CLI. The three sat on the same library with two different ceilings for no reason.

The lock's path-dependency entries were edited to match, since poetry lock cannot reach files.pythonhosted.org from here. They carry no hashes and no file list, poetry check --lock passes, and poetry install resolves with nothing left to fetch.