### PR TITLE
fix(ci): deploy versioned docs off the publish run, not the release e…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,6 +118,12 @@ that task fails for reasons unrelated to your change.
   `github/codeql-action` uses, need the `^{}` or you compare against the tag object.
 - **A 200 response does not mean a badge rendered.** shields.io returns 200 with the words
   "rate limited by upstream service" drawn into the SVG. Inspect the rendered text.
+- **A `GITHUB_TOKEN`-created event never triggers another workflow.** `publish.yml` creates
+  the GitHub Release, so a `release:` trigger anywhere else is dead code — the versioned
+  docs deploy sat unreachable through two releases. `docs.yml` chains off `workflow_run` of
+  `Publish` instead. The exceptions are `workflow_dispatch` and `repository_dispatch`.
+- **`publish.yml` triggers on `v*.*.*`, not `v*`.** `actions/validate` is advertised as
+  `@v1`, and moving that tag used to start a publish run that failed the tag guard.
 - **An optional provider capability is a flag plus a raising default**, never an empty
   return. See [ADR 0002](../docs/adr/0002-optional-provider-capabilities.md):
   `supports_resource_listing` / `supports_discovery` are plain attributes, not `ClassVar`,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,16 +17,29 @@ on:
       - "README.md"
       - "packages/**"
       - ".github/workflows/docs.yml"
-  release:
-    types: [published]
+  # The Release is created by publish.yml with GITHUB_TOKEN, and GitHub does not
+  # trigger workflows for GITHUB_TOKEN-created events, so a `release` trigger here
+  # is unreachable. Chain off the publish run instead, which also means docs only
+  # ship for a release that actually reached PyPI.
+  workflow_run:
+    workflows: [Publish]
+    types: [completed]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Deploy docs for this already-released version, e.g. 0.4.0. Empty builds only."
+        required: false
+        default: ""
 
 jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
+      # Build what deploy will publish, not whatever main happens to be.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -53,13 +66,17 @@ jobs:
 
   deploy:
     name: Deploy versioned docs
-    if: github.event_name == 'release'
+    if: >-
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+      || (github.event_name == 'workflow_dispatch' && inputs.version != '')
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -82,7 +99,17 @@ jobs:
             ./packages/testing/agentskills-testing
 
       - name: Publish docs for release tag
+        env:
+          TAG: ${{ github.event.workflow_run.head_branch }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          set -euo pipefail
+          VERSION="${INPUT_VERSION:-${TAG#v}}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::notice::'$VERSION' is not a stable release; not deploying docs."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           mike deploy --push --update-aliases "$VERSION" latest
           mike set-default --push latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,9 @@ name: Publish
 on:
   push:
     tags:
-      - "v*"
+      # Not `v*`: `actions/validate` is advertised as `@v1`, and moving that tag
+      # must not look like a release.
+      - "v*.*.*"
   workflow_dispatch: # build-only dry run, publishes nothing
 
 permissions: {}


### PR DESCRIPTION
…vent

The Release is created by publish.yml using GITHUB_TOKEN, and GitHub does not trigger workflows for GITHUB_TOKEN-created events, so the release-gated deploy job in docs.yml has never run. There is no gh-pages branch and no Pages site, for v0.3.0 or v0.4.0.

Chains the deploy off workflow_run of Publish, which also means docs only ship for a release that actually reached PyPI, and adds a version input so an already-released version can be backfilled. Both jobs now check out the commit being released rather than whatever main is. Sets a git identity for mike and refuses to move the latest alias for a pre-release.

Also narrows the publish trigger from v* to v*.*.*: actions/validate is advertised as @v1, and pushing that tag started a publish run that failed the tag guard.