### PR TITLE
docs: specify all six v0.5 roadmap items

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,14 +102,18 @@ Everything before this makes skills safe and cheap to ship. This milestone is ab
 **worth** shipping — the point where the SDK stops being a loader and starts changing how well the
 agent performs.
 
+The first two items change contracts the rest build on — the frontmatter schema and the shape of a
+body fetch — so the table is ordered by dependency rather than by value. Specifications:
+[docs/issues/v0.5.md](./issues/v0.5.md).
+
 | Item | Theme | Package(s) | Notes |
 |---|---|---|---|
-| Semantic skill selection | Agent effectiveness | new `agentskills-retrieval` | The catalog is injected on every turn, so prompt cost is linear in registered skills. Embed descriptions once, select top-k against the current turn, inject a handful. Descriptions are already written to be discriminative, so the corpus exists for free. Ships with a zero-dependency lexical default; embeddings are pluggable. Opt-in, and it must log its selection — this trades a deterministic prompt for a better one. |
-| Section-level disclosure | Agent effectiveness | `agentskills-core` + integrations | `get_skill_body()` is all-or-nothing, so a thorough 4k-token skill is charged in full to use one section. Split the body by heading, return an outline plus `get_skill_section(skill_id, heading)`. Extends progressive disclosure one level inward rather than adding a new idea, and stops penalising well-written skills. |
-| Stateful / session-aware disclosure | Agent effectiveness | `agentskills-agentframework` | Use the context provider's session `state` and `after_run` hook to track which skills the agent already loaded, prune the advertised catalog to the active domain, and inject resource-level tools only for loaded skills. Turns progressive disclosure into a framework-level behaviour rather than a prompt instruction. |
-| Vision-native assets | Agent effectiveness | integrations | Once binary resources are safe (v0.3), stop stringifying them: hand images to multimodal models as native content. A skill can then carry an architecture diagram or a UI screenshot that the model actually sees. |
 | Selection metadata | Correctness | `agentskills-core` | Optional `when_to_use` / `when_not_to_use` frontmatter. False activation is as damaging as non-activation, and a description alone carries no negative signal. Improves both LLM selection and retrieval ranking. Optional and backward-compatible per principle 1; push upstream. |
+| Section-level disclosure | Agent effectiveness | `agentskills-core` + integrations | `get_skill_body()` is all-or-nothing, so a thorough 4k-token skill is charged in full to use one section. Split the body by heading, return an outline plus `get_skill_section(skill_id, heading)`. Extends progressive disclosure one level inward rather than adding a new idea, and stops penalising well-written skills. |
+| Semantic skill selection | Agent effectiveness | new `agentskills-retrieval` | The catalog is injected on every turn, so prompt cost is linear in registered skills. Embed descriptions once, select top-k against the current turn, inject a handful. Descriptions are already written to be discriminative, so the corpus exists for free. Ships with a zero-dependency lexical default; embeddings are pluggable. Opt-in, and it must log its selection — this trades a deterministic prompt for a better one. |
+| Stateful / session-aware disclosure | Agent effectiveness | `agentskills-agentframework` | Use the context provider's session `state` and `after_run` hook to track which skills the agent already loaded, prune the advertised catalog to the active domain, and inject resource-level tools only for loaded skills. Turns progressive disclosure into a framework-level behaviour rather than a prompt instruction. |
 | Single-skill fast path | Performance | integrations | When exactly one skill is registered or selected, inject the body directly instead of advertising a tool and waiting for the agent to call it. Removes a full round-trip from the common single-purpose-agent case. |
+| Vision-native assets | Agent effectiveness | integrations | Once binary resources are safe (v0.3), stop stringifying them: hand images to multimodal models as native content. A skill can then carry an architecture diagram or a UI screenshot that the model actually sees. |
 
 ---
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -12,7 +12,7 @@ Each file covers one milestone, in the same order as the corresponding roadmap t
 |---|---|---|
 | [v0.3 — Foundations](./v0.3.md) | 12 | Specified |
 | [v0.4 — Developer Experience](./v0.4.md) | 12 | Specified |
-| [v0.5 — Agent Effectiveness](./v0.5.md) | 1 of 6 | Partly specified — the remaining items need design work first |
+| [v0.5 — Agent Effectiveness](./v0.5.md) | 6 | Specified |
 | v0.6 — Trust & Operability | — | Not specified; see the [roadmap](../ROADMAP.md) |
 | v0.7 — Ecosystem | — | Not specified; see the [roadmap](../ROADMAP.md) |
 | v1.0 — Stability | — | Not specified; see the [roadmap](../ROADMAP.md) |
@@ -46,6 +46,6 @@ than being quietly deleted.
 | Prefix | Values |
 |---|---|
 | `theme:` | `correctness`, `performance`, `resilience`, `agent-effectiveness`, `interoperability`, `trust`, `operability`, `dx`, `ecosystem`, `project-health` |
-| `package:` | `core`, `fs`, `http`, `langchain`, `agentframework`, `mcp-server`, `cli`, `testing`, `retrieval`, `adapters` |
+| `package:` | `core`, `fs`, `http`, `langchain`, `agentframework`, `mcp-server`, `tools`, `testing`, `retrieval`, `adapters` |
 | `type:` | `bug`, `feature`, `docs`, `chore` |
 | flat | `good-first-issue`, `help-wanted`, `breaking-change` |

--- a/docs/issues/v0.4.md
+++ b/docs/issues/v0.4.md
@@ -9,7 +9,7 @@ Add the GitHub issue number to a heading once the item is filed.
 
 ## 1. `agentskills` CLI
 
-**Labels:** `theme:dx`, `type:feature`, `package:cli`
+**Labels:** `theme:dx`, `type:feature`, `package:tools`
 
 > **Status: implemented.** Both open questions were resolved toward the dependency-light
 > answer; see the implementation notes.
@@ -629,7 +629,7 @@ and all four filter arguments.
 > and an on-disk cache keyed by what actually determined each completion. The harness landed in
 > `agentskills-tools` rather than `agentskills-testing`; the reasoning is below.
 
-**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:cli`
+**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:tools`
 
 **Depends on:** item 1 (CLI), item 4 (test doubles)
 
@@ -855,7 +855,7 @@ providers; focused tests cover all supported source shapes and validation.
 
 ## 9. Token cost reporting
 
-**Labels:** `theme:dx`, `type:feature`, `package:cli`
+**Labels:** `theme:dx`, `type:feature`, `package:tools`
 
 > **Status: implemented.** The open question was resolved toward the dependency-light default,
 > but with a lever attached: `tiktoken` is used when importable and a character heuristic

--- a/docs/issues/v0.5.md
+++ b/docs/issues/v0.5.md
@@ -3,13 +3,275 @@
 Specifications for the v0.5 roadmap items, in the same order as the table in the
 [roadmap](../ROADMAP.md). Milestone: `v0.5`.
 
-The other v0.5 items (semantic skill selection, section-level disclosure, vision-native assets,
-selection metadata, single-skill fast path) still need design work before they can be specified
-here. The one below is scoped enough to act on, and is item 3 in the roadmap table.
+Add the GitHub issue number to a heading once the item is filed.
+
+Items 1 and 2 change contracts the rest of the milestone builds on — the frontmatter schema and
+the shape of a body fetch. They are ordered first so the others are specified against a settled
+surface rather than a guessed one. Items 3, 5 and 6 are leaf work that can proceed in parallel
+once those land.
 
 ---
 
-## 3. Session-aware progressive disclosure in the context provider
+## 1. Selection metadata: `when_to_use` and `when_not_to_use`
+
+**Labels:** `theme:correctness`, `type:feature`, `package:core`
+
+### Problem
+
+`description` is the only signal an agent has when choosing a skill, and it carries positive
+evidence only. There is no way to say where a skill stops applying — that `incident-response` is
+for a production outage and not for a failing test on a laptop.
+
+False activation is not a lesser failure than non-activation. It is worse. Non-activation costs
+the tokens of a catalog entry the agent ignored; false activation costs a full body load *and*
+puts instructions written for a different situation in front of the model, which then follows
+them. The SDK currently has no vocabulary for expressing the boundary.
+
+Authors work around this by folding negative conditions into `description`. That is the wrong
+place for three reasons: `description` is capped at 1024 characters by `validate_skill()`, so the
+negative signal competes for room with the positive one; it is charged on **every turn** for
+**every registered skill**, whether or not that skill is ever used; and a description that reads
+"use for X, but not Y, unless Z" is worse at its primary job of being discriminative.
+
+This item is first in the milestone because item 3 ranks skills over a text corpus. Deciding
+what fields exist after the ranking is built means specifying the corpus twice.
+
+### Proposal
+
+Two optional frontmatter fields, each a list of short strings:
+
+```yaml
+---
+name: incident-response
+description: Triage and mitigate production incidents.
+when_to_use:
+  - A production service is degraded or down
+  - An alert has fired and needs triage
+when_not_to_use:
+  - Debugging a failing test locally
+  - Planning capacity for a future launch
+---
+```
+
+Implementation is deliberately small. Add both to `_OPTIONAL_FIELDS` in `agentskills_core.validation`
+with type `list`, which extends `_KNOWN_KEYS` for free, and add an element-level check that every
+entry is a non-empty string. Nothing else in core needs to know they exist.
+
+They surface in the catalog next to the description, and only when set — the same rule `version`
+already follows, so an unversioned skill without selection metadata renders byte-identical to
+today:
+
+```xml
+<skill>
+  <name>incident-response</name>
+  <description>Triage and mitigate production incidents.</description>
+  <when_to_use>
+    <case>A production service is degraded or down</case>
+  </when_to_use>
+  <when_not_to_use>
+    <case>Debugging a failing test locally</case>
+  </when_not_to_use>
+</skill>
+```
+
+**These fields are charged on every turn, so they must be bounded and they must be droppable.**
+Cap each entry at 200 characters and each list at five entries — a sixth condition is a sign the
+skill should be split. Add `get_skills_catalog(..., selection_hints=False)` for callers who want
+the cheap catalog back. Without both of those this feature is a way to quietly triple the
+per-turn cost of a registry.
+
+Tooling follows: `agentskills lint` warns when a skill has neither field and a description over
+some length (the author is probably already smuggling conditions into it), `agentskills init`
+scaffolds both as commented examples, and `agentskills inspect --turn-budget` must count them —
+a per-turn budget that ignores per-turn fields is not a budget.
+
+Per product principle 1 these stay optional and backward-compatible, and the design should be
+taken upstream to the [Agent Skills specification](https://agentskills.io/specification) rather
+than kept as a local extension.
+
+### Open questions
+
+- **`list[str]` or a single free-text string?** A list renders and ranks cleanly and bounds
+  naturally; a string is nicer to write and does not push authors into telegraphic fragments.
+- **Top-level, or inside the free-form `metadata` mapping?** `tags` went into `metadata`
+  precisely to avoid needing anything defended upstream. The same argument applies here and cuts
+  against a top-level field — but selection metadata is far more central than tags, and burying
+  it hurts discoverability.
+- **Should `when_not_to_use` be injected at all, or only used for ranking?** Negative conditions
+  may be more valuable to a retrieval scorer than to the model, and keeping them out of the
+  prompt would halve the added per-turn cost.
+- **Does an empty list mean "no restrictions" or "author has not thought about it"?** Lint needs
+  to tell those apart to say anything useful.
+
+### Acceptance criteria
+
+- [ ] `when_to_use` / `when_not_to_use` validated as lists of non-empty strings, both optional
+- [ ] Per-entry and per-list limits enforced with a clear error naming the limit
+- [ ] Both rendered in the XML and markdown catalogs, omitted entirely when absent
+- [ ] `selection_hints=False` restores the current catalog output byte-for-byte
+- [ ] A skill written before this change validates and renders unchanged
+- [ ] `inspect --turn-budget` counts them; `lint` warns when both are missing
+- [ ] Fields documented in the concepts page and proposed upstream
+
+---
+
+## 2. Section-level disclosure
+
+**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:core`, `package:langchain`, `package:agentframework`, `package:mcp-server`
+
+### Problem
+
+Progressive disclosure currently has two levels and then a cliff. An agent sees a catalog entry
+(tens of tokens), and the only way to learn anything more is `get_skill_body()`, which returns
+the entire markdown body. A thorough 4,000-token skill charges all 4,000 to answer a question
+covered by one 300-token section.
+
+This penalises exactly the skills that are worth writing. An author who documents six scenarios
+properly produces a skill that is more expensive to consult than a shallow one, so the format
+quietly rewards thin content. That inverts the point of the product.
+
+The building block already exists in the wrong package: `split_sections()` in
+`agentskills_tools.cost` splits a body at its headings, respects fenced code blocks so a `#` shell
+comment is not read as a heading, and guarantees the parts sum to the whole. `agentskills
+inspect --cost` already shows authors a per-section breakdown — the SDK can measure what a
+section costs but cannot serve one.
+
+### Proposal
+
+Promote sectioning into `agentskills-core` and expose it one level below the body.
+
+- Move `Section` and `split_sections()` into `agentskills_core`, and have `agentskills-tools`
+  import them rather than keep its own copy. The v0.4 notes already flagged cross-package
+  duplication of parsing constants as a drift trap; this is the same trap with an algorithm.
+- `Skill.get_outline() -> list[SectionRef]` and `SkillRegistry.get_skill_outline(skill_id)`,
+  returning title, level, an addressable key, and an estimated size per section.
+- `Skill.get_section(key) -> str` and `SkillRegistry.get_skill_section(skill_id, key)`, raising a
+  `SectionNotFoundError` in the existing `LookupError` family.
+- Two new tools — `get_skill_outline`, `get_skill_section` — in all three integrations.
+
+**This must not become a provider capability.** It is computed on top of `get_body()`, which
+providers already cache, so no third-party provider has to grow a markdown parser and the ADR
+0002 capability-flag machinery stays out of it. The outline of a skill is a property of its
+content, not of where the content is stored.
+
+**A section fetch is not automatically cheaper than a body fetch.** Each one costs a tool call,
+a model turn, and the tokens of the outline that preceded it. For a 600-token body the round
+trip is pure loss. The outline tool should therefore report the body's total size and say
+plainly when fetching the whole thing is cheaper, using the same token counter as
+`inspect --cost` so the two never disagree. Shipping this without that guidance makes the common
+case worse in order to improve the rare one.
+
+### Open questions
+
+- **Addressing.** Headings are not unique — `## Setup` can legitimately appear twice.
+  Slug-plus-ordinal is simple and matches the flat, non-overlapping model `split_sections()`
+  already uses. A hierarchical path (`installation/setup`) reads better but implies a tree the
+  splitter does not build.
+- **The outline reports `level` but addressing is flat.** Showing nesting the address space does
+  not model is at best confusing. Either the splitter grows real nesting or the outline stops
+  advertising depth.
+- **Where does the size threshold live** — a core constant, a registry argument, or purely
+  advisory text in the tool description?
+- **Should `get_skill_body` gain a `sections=[...]` argument** instead of a separate tool, so an
+  agent can fetch three sections in one call rather than three?
+
+### Acceptance criteria
+
+- [ ] `Section` / `split_sections()` live in core; tools re-exports rather than reimplements
+- [ ] `get_skill_outline` and `get_skill_section` on `Skill` and `SkillRegistry`
+- [ ] Unknown section key raises a `LookupError` subclass, consistent with the taxonomy
+- [ ] No change to the `SkillProvider` ABC and no new capability flag
+- [ ] Both tools exposed in the LangChain, Agent Framework, and MCP integrations
+- [ ] Outline reports total body size and identifies when a whole-body fetch is cheaper
+- [ ] A body with no headings yields a single section and still works end to end
+- [ ] Conformance suite unchanged — this is not a provider concern
+
+---
+
+## 3. Semantic skill selection
+
+**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:retrieval`
+
+**Depends on:** item 1 (selection metadata supplies the corpus)
+
+### Problem
+
+The catalog is injected on every turn, so per-turn prompt cost is linear in the number of
+registered skills. `get_skills_catalog()` already offers `include`, `exclude`, `tags` and
+`max_chars`, but every one of those requires the caller to know the answer in advance. Nothing
+narrows the catalog based on what the user actually asked.
+
+Two costs compound. The obvious one is tokens: at fifty skills the catalog alone is thousands of
+tokens on every turn of every conversation. The less obvious one is accuracy — selection quality
+degrades as the candidate list grows, so a large registry is worse at picking the right skill
+*and* charges more for the privilege. `max_chars` is not a substitute; it drops entries from the
+end, which is arbitrary with respect to relevance.
+
+### Proposal
+
+A new `agentskills-retrieval` package. A `SkillSelector` protocol with one method returning
+scored skill IDs, and two implementations:
+
+- **`LexicalSelector`** — zero-dependency BM25 over description, `when_to_use`, `when_not_to_use`
+  and tags. The default, so the package is useful with nothing else installed.
+- **`EmbeddingSelector`** — embeds each skill's text once and ranks by cosine similarity. The
+  embedder is a one-method protocol resolved from a dotted path, exactly as the v0.4 eval harness
+  resolves models, so no embedding SDK becomes a dependency of anything.
+
+**The integration point already exists.** A selector returns skill IDs; those IDs feed the
+existing `include=` filter, which runs *before* any metadata is fetched — so narrowing to five of
+fifty skills also avoids forty-five provider round trips. Core needs no new code and gains no
+knowledge of retrieval. If a design for this requires changing `agentskills-core`, it is the
+wrong design.
+
+Embeddings are computed once per skill and cached by content hash, so re-registering an unchanged
+skill is free and editing one invalidates only itself. In-memory by default with a hook for
+persistence; a hosted registry should not re-embed its corpus on every process start.
+
+**Selection must be visible.** This trades a deterministic prompt for a better one, and a skill
+that was scored out is indistinguishable, from inside the agent, from a skill that was never
+registered. So: log every selection with its scores, and report it in the catalog the way
+truncation already is — `selected="5" total="50"` on the XML root, a closing note in markdown.
+
+### Open questions
+
+- **How is this measured?** The v0.4 eval harness measures whether a skill helps once the model
+  has it; that is a different question from whether the right skill was chosen. Selection needs a
+  labelled fixture set — queries paired with the skill that should win — and a recall@k number
+  that has to clear a bar before the feature is recommended. The roadmap already warns that
+  catalog pruning must be evaluated before it becomes a default; shipping ranking without a
+  measurement is that mistake one item earlier.
+- **What is the query?** The last user message is the obvious choice and is wrong for
+  conversations where the topic was established several turns ago.
+- **Does the selector see negative conditions?** `when_not_to_use` is a demotion signal, not a
+  match signal, and BM25 has no natural way to express that.
+- **Separate package or a core extra?** Precedent from v0.4 item 1 says separate package. Worth
+  restating explicitly rather than inheriting by accident.
+- **A floor as well as a top-k?** Returning the five best of fifty irrelevant skills is worse
+  than returning nothing and letting the agent answer directly.
+
+### Notes
+
+`agentskills-retrieval` is a new distribution, so before the v0.5.0 tag it needs a tenth entry in
+every place a package must be registered (root `pyproject.toml` three times, `COVERAGE_FLOORS`,
+both bump scripts, `check_release_version.py`, `check_declared_dependencies.py`, `publish.yml`
+twice, `docs.yml` twice, `mkdocs.yml` nav, and a `docs/packages/` page) plus a pending trusted
+publisher on PyPI — and only one pending publisher can exist at a time, so it must be registered
+alone. The name and its ultranormalized neighbours were free on PyPI as of 2026-08-17.
+
+### Acceptance criteria
+
+- [ ] `agentskills-retrieval` published, with `LexicalSelector` usable with zero extra dependencies
+- [ ] `EmbeddingSelector` with a dotted-path embedder protocol and no vendor SDK dependency
+- [ ] Selector output composes with `include=` and requires no change to `agentskills-core`
+- [ ] Embeddings cached by content hash, with a documented persistence hook
+- [ ] Every selection logged with scores, and reported in both catalog formats
+- [ ] A labelled fixture set and a published recall@k for both selectors
+- [ ] Opt-in; the default path is byte-identical to today
+
+---
+
+## 4. Session-aware progressive disclosure in the context provider
 
 **Labels:** `theme:agent-effectiveness`, `type:feature`, `package:agentframework`
 
@@ -64,6 +326,8 @@ skill content carries source attribution and can be filtered by other providers 
 ### Notes
 
 - (a) and (b) are the core of the issue; (d) needs an evaluation harness before it can be trusted.
+- (d) is item 3 solved a second time, worse — with conversation state but without a measurement. Prefer running item 3's selector here over inventing a second ranker in an integration package.
+- (c) is far more valuable once item 2 lands: the tool surface then grows per *section* as well as per skill.
 - Anything here that generalises beyond Agent Framework should land in `agentskills-core` so the LangChain and MCP paths benefit too.
 - API reference: [`_sessions.py`](https://github.com/microsoft/agent-framework/blob/e8a7ffbc14fbac54dbbeeaaaf94d78094526ad22/python/packages/core/agent_framework/_sessions.py#L272)
 
@@ -73,3 +337,139 @@ skill content carries source attribution and can be filtered by other providers 
 - [ ] Loaded skills tracked in provider-scoped `state`
 - [ ] Repeated `before_run()` calls remain idempotent
 - [ ] Token count for turn N+1 measurably lower than today for a multi-turn session
+
+---
+
+## 5. Single-skill fast path
+
+**Labels:** `theme:performance`, `type:feature`, `package:langchain`, `package:agentframework`, `package:mcp-server`
+
+**Depends on:** item 3 (the selected set, not just the registered set)
+
+### Problem
+
+An agent with exactly one registered skill pays the full discovery apparatus to reach content
+there was never a choice about. Today that means a catalog listing one skill, five tool
+definitions, a block of usage instructions describing a multi-step workflow, and then a complete
+model round trip while the agent calls `get_skill_body` and waits.
+
+Every part of that is waste in the single-skill case. A catalog exists to let a model choose;
+there is nothing to choose. Usage instructions describe a workflow with one branch. And the round
+trip adds latency plus a second billed model turn to deliver text that could have been in the
+first prompt.
+
+This is also the shape of most first contact with the SDK — one skill, one agent, one job — so
+the configuration people evaluate the library on is the one it handles least efficiently.
+
+### Proposal
+
+When the effective skill set is exactly one, inject that skill's body directly into the
+instructions and skip the catalog, the usage instructions, and the body-fetch tool.
+
+"Effective" means after filtering and selection, not merely `len(registry.list_skills()) == 1`.
+A registry of fifty narrowed to one by item 3 is the same situation and should take the same
+path — which is why this is specified after retrieval.
+
+Resource tools stay. References, scripts and assets are still genuinely progressive, and a skill
+that carries a 2 MB dataset must not have it inlined because the skill count happened to be one.
+
+**Body size decides whether this is a win, so it has to be a named threshold rather than an
+assumption.** Inlining a 20,000-token body on every turn of a long conversation is strictly worse
+than one tool call that happens once. Gate on a token ceiling using the same counter as item 2,
+default it conservatively, and log when the fast path was declined and why — silently taking a
+different code path based on content size is the kind of behaviour that makes token bills
+impossible to explain.
+
+Ship it opt-in. Promote it to the default only once the numbers are in.
+
+### Open questions
+
+- **What is the ceiling, and is it tokens or turns?** A body worth inlining for a three-turn
+  conversation may not be for a thirty-turn one, and the integration knows the former but not the
+  latter.
+- **Does the agent still need the usage instructions?** They explain resource tools too, so
+  dropping them wholesale may leave the model unaware it can read references.
+- **Interaction with item 4(a).** Once the prompt is cached per session, the repeated-injection
+  cost this item avoids is already partly paid down; the two need measuring together rather than
+  separately.
+- **Does the skill's identity still need to be visible** so the agent can attribute its
+  behaviour, or does the body simply become part of the system prompt?
+
+### Acceptance criteria
+
+- [ ] Opt-in flag on all three integrations with consistent naming
+- [ ] Triggers on the effective set of one, including a set narrowed by selection
+- [ ] Resource tools remain available; only the catalog, instructions and body tool are dropped
+- [ ] Token ceiling enforced, configurable, and logged when the fast path is declined
+- [ ] Measured saving published for a single-skill agent over a representative conversation
+- [ ] Default path unchanged when the flag is off
+
+---
+
+## 6. Vision-native assets
+
+**Labels:** `theme:agent-effectiveness`, `type:feature`, `package:core`, `package:langchain`, `package:agentframework`, `package:mcp-server`
+
+**Depends on:** the binary-safe resource envelope shipped in v0.3
+
+### Problem
+
+Every integration returns resource content as `str`, so `encode_resource_content()` wraps anything
+that is not valid UTF-8 in a JSON envelope with base64 in a `content` field. For a PNG that means
+the model receives a description of an image instead of an image.
+
+The token economics are the worst available. Base64 inflates the payload by about a third, the
+result tokenizes as unstructured noise at roughly one token per few characters, and the model
+cannot see any of it — so a diagram costs thousands of tokens to convey exactly nothing. The
+64 KiB inline cap makes it worse in a different way: most real screenshots exceed it, so they
+come back as a stub saying the file was too large to include. Either way an author cannot ship a
+skill that shows the agent an architecture diagram or a UI screenshot.
+
+v0.3 made binary resources *safe* — they are no longer silently corrupted by
+`decode("utf-8", errors="replace")` — and explicitly deferred making them *useful*. This is that
+follow-up.
+
+### Proposal
+
+Stop stringifying resources the host can render natively, and hand them to the model as content
+blocks:
+
+| Integration | Native representation |
+|---|---|
+| MCP | `ImageContent` — already in the protocol, and the specific follow-up v0.3 named |
+| LangChain | multimodal content blocks on the message |
+| Agent Framework | the framework's binary/data content type |
+
+Core gains one small classifier — given a filename and bytes, report the media type and whether
+it is a candidate for native rendering — so the three integrations cannot drift on what counts as
+an image. `encode_resource_content()` stays exactly as it is and remains the fallback for
+everything else; this adds a branch above it rather than replacing it.
+
+**The 64 KiB inline cap should become per-modality.** It was chosen for base64 in a text field,
+where size maps directly to tokens. A natively-attached image is charged by tile count, so the
+old number is both too small for images and irrelevant to how they are billed.
+
+### Open questions
+
+- **This changes a tool's return type from `str` to a union, in all three integrations.** That is
+  a breaking change to the tool contract and needs either a version gate or an opt-in flag, and
+  the decision should be recorded as an ADR alongside
+  [ADR 0007](../adr/0007-binary-resource-json-envelope.md) rather than quietly amending it.
+- **What happens on a text-only model?** Handing an image block to a model that cannot accept one
+  is an API error, not a degradation. The integration may not know the model's modality, in which
+  case this has to be caller-declared.
+- **Which formats qualify?** PNG, JPEG, GIF and WebP are uncontroversial. PDF is supported
+  natively by some models and not others; SVG is text, so it already arrives readable and
+  arguably should not be converted to a raster block.
+- **Does `list_skill_resources` need to advertise renderability**, so the agent knows an asset is
+  worth requesting before it spends a tool call finding out?
+
+### Acceptance criteria
+
+- [ ] Media-type and renderability classifier in core, used by all three integrations
+- [ ] Images returned as native content blocks in MCP, LangChain, and Agent Framework
+- [ ] Non-renderable resources keep the existing JSON envelope, unchanged
+- [ ] Per-modality size limits, documented, replacing the single inline cap
+- [ ] Behaviour on a text-only model is defined and tested, not an exception from the provider API
+- [ ] ADR recorded for the tool return-type change
+- [ ] An example skill carrying an image, with a test proving the model receives it natively


### PR DESCRIPTION
v0.5 had one of six items written up. Adds specifications for selection metadata, section-level disclosure, semantic skill selection, the single-skill fast path, and vision-native assets, each with problem, proposal, open questions and acceptance criteria.

Reorders the v0.5 roadmap table by dependency rather than value: selection metadata defines the corpus that retrieval ranks over, and section-level disclosure changes the body-fetch contract the session-aware and fast-path items build on. The issues file is required to match the roadmap order, so both move together and the existing item 3 becomes item 4.

Also retires the package:cli label for package:tools after the distribution rename.