### PR TITLE
ci: pin codeql-action init and analyze to the same version

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,6 +116,10 @@ that task fails for reasons unrelated to your change.
   appeared twice. The SHA is right and the comment is not, so read it as decoration and
   confirm with `git ls-remote --tags <repo> 'refs/tags/vX.Y.Z^{}'` — annotated tags, which
   `github/codeql-action` uses, need the `^{}` or you compare against the tag object.
+- **`codeql-action/init` and `/analyze` must be pinned to the same version.** A mismatch fails
+  the scan with "Loaded a configuration file for version X, but running version Y". Dependabot
+  raises one PR per sub-action, so merging either alone breaks CodeQL until the other lands;
+  `dependabot.yml` now groups them under `codeql-action` to stop that.
 - **A 200 response does not mean a badge rendered.** shields.io returns 200 with the words
   "rate limited by upstream service" drawn into the SVG. Inspect the rendered text.
 - **A `GITHUB_TOKEN`-created event never triggers another workflow.** `publish.yml` creates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,9 @@ updates:
       - ci
     commit-message:
       prefix: "ci:"
+    groups:
+      # codeql-action/init and /analyze are one product; bumping them in separate
+      # PRs breaks the scan for however long the second one sits unmerged.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        # init and analyze must be the same version; CodeQL refuses to run on a mismatch.
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: python
 


### PR DESCRIPTION
CodeQL has failed on every run since #124 merged.

Dependabot raises one PR per `codeql-action` sub-action. #124 bumped `analyze` to v4.37.7 while the matching `init` bump is still open, and CodeQL refuses to run on a version mismatch:

```
Loaded a configuration file for version '4.37.6', but running version '4.37.7'
```

- Pins `init` to the same v4.37.7 SHA as `analyze` (`ff2f1c62`, resolved via `git ls-remote --tags`).
- Groups `github/codeql-action*` in `dependabot.yml` so the two can never be split across PRs again.
- Records the trap in `.github/copilot-instructions.md`.

Supersedes the open `dependabot/github_actions/github/codeql-action/init-4.37.7` PR.