### PR TITLE
chore(release): bump all packages to 0.5.0

### DIFF
--- a/packages/adapters/agentskills-adapters/pyproject.toml
+++ b/packages/adapters/agentskills-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-adapters"
-version = "0.4.0"
+version = "0.5.0"
 description = "Adapters from common agent instruction formats to Agent Skills (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 pyyaml = ">=6.0,<7.0"
 
 [build-system]

--- a/packages/core/agentskills-core/pyproject.toml
+++ b/packages/core/agentskills-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-core"
-version = "0.4.0"
+version = "0.5.0"
 description = "Storage-agnostic abstractions for discovering, validating, and accessing Agent Skills (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]

--- a/packages/integrations/agentskills-agentframework/pyproject.toml
+++ b/packages/integrations/agentskills-agentframework/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-agentframework"
-version = "0.4.0"
+version = "0.5.0"
 description = "Microsoft Agent Framework integration for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 # 1.0.0 renamed BaseContextProvider to ContextProvider; earlier prereleases are incompatible.
 agent-framework-core = ">=1.0,<2.0"
 

--- a/packages/integrations/agentskills-langchain/pyproject.toml
+++ b/packages/integrations/agentskills-langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-langchain"
-version = "0.4.0"
+version = "0.5.0"
 description = "LangChain integration for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 langchain-core = ">=1.0,<2.0"
 
 [build-system]

--- a/packages/integrations/agentskills-mcp-server/pyproject.toml
+++ b/packages/integrations/agentskills-mcp-server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-mcp-server"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server integration for the Agent Skills format — expose skills as MCP tools and resources (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 mcp = ">=1.28.1,<2"
 pydantic = ">=2.0"
 agent-framework-core = {version = ">=1.0,<2.0", optional = true}

--- a/packages/providers/agentskills-fs/pyproject.toml
+++ b/packages/providers/agentskills-fs/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-fs"
-version = "0.4.0"
+version = "0.5.0"
 description = "Filesystem-based skill provider for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 pyyaml = ">=6.0,<7.0"
 
 [build-system]

--- a/packages/providers/agentskills-http/pyproject.toml
+++ b/packages/providers/agentskills-http/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-http"
-version = "0.4.0"
+version = "0.5.0"
 description = "HTTP-based skill providers for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 httpx = ">=0.27,<1.0"
 pyyaml = ">=6.0,<7.0"
 

--- a/packages/retrieval/agentskills-retrieval/pyproject.toml
+++ b/packages/retrieval/agentskills-retrieval/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-retrieval"
-version = "0.4.0"
+version = "0.5.0"
 description = "Query-time skill selection for the Agent Skills format (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/packages/testing/agentskills-testing/pyproject.toml
+++ b/packages/testing/agentskills-testing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-testing"
-version = "0.4.0"
+version = "0.5.0"
 description = "Conformance suite and test doubles for Agent Skills providers (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -21,7 +21,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 pytest = ">=8.0"
 pytest-asyncio = ">=0.24"
 pyyaml = ">=6.0,<7.0"

--- a/packages/tools/agentskills-tools/pyproject.toml
+++ b/packages/tools/agentskills-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-tools"
-version = "0.4.0"
+version = "0.5.0"
 description = "Command line tools for authoring and validating Agent Skills (https://agentskills.io)"
 license = "MIT"
 authors = ["Pratik Panda"]
@@ -20,7 +20,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-agentskills-core = ">=0.4.0,<1.0"
+agentskills-core = ">=0.5.0,<1.0"
 agentskills-adapters = ">=0.3.0,<1.0"
 agentskills-fs = ">=0.3.0,<1.0"
 pyyaml = ">=6.0,<7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentskills-sdk"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python SDK for the Agent Skills open format (https://agentskills.io)"
 license = "MIT"
 package-mode = false


### PR DESCRIPTION
Lockstep bump of the workspace root and all ten packages from `0.4.0` to `0.5.0`, ahead of tagging `v0.5.0`.

Each dependent package also moves its `agentskills-core` floor to `>=0.5.0,<1.0`, so a v0.5 install cannot silently resolve against a v0.4 core. `scripts/check_release_version.py` enforces that floor, so it is not a stylistic choice.

`agentskills-retrieval` ships to PyPI for the first time in this release; its pending trusted publisher is registered.

## What v0.5 contains

The milestone is feature-complete; this PR only carries the version numbers.

| Item | PR |
| --- | --- |
| Selection metadata (`when_to_use` / `when_not_to_use`) | #126 |
| Section-level progressive disclosure | #127 |
| Semantic skill selection (`agentskills-retrieval`) | #128 |
| Session-aware progressive disclosure | #129 |
| Single-skill fast path | #130 |
| Vision-native assets | #131 |

## Verification

```
check_release_version.py --tag v0.5.0   OK: all 10 packages at 0.5.0, matching v0.5.0
check_declared_dependencies.py          OK: all 10 packages declare what they import
ruff check / ruff format --check        clean, 117 files
pytest packages                         1403 passed, 7 skipped
```

`poetry.lock` is deliberately untouched. The root pyproject declares the workspace packages as path dependencies without version constraints, so its content hash does not move when package versions do, and the lockfile stays valid.
