### PR TITLE
docs: reflect the v0.5.0 release

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,28 +96,31 @@ existing users.
 
 ---
 
-## Now — v0.5 "Agent Effectiveness"
+## Shipped — v0.5 "Agent Effectiveness"
 
-Everything before this makes skills safe and cheap to ship. This milestone is about making them
-**worth** shipping — the point where the SDK stops being a loader and starts changing how well the
-agent performs.
-
-The first two items change contracts the rest build on — the frontmatter schema and the shape of a
-body fetch — so the table is ordered by dependency rather than by value. Specifications:
+Released 2026-08-19. Everything before this makes skills safe and cheap to ship. This milestone is
+about making them **worth** shipping — the point where the SDK stops being a loader and starts
+changing how well the agent performs. Specifications and implementation notes:
 [docs/issues/v0.5.md](./issues/v0.5.md).
+
+One new distribution ships with this milestone — `agentskills-retrieval` — bringing the
+lockstep-versioned set to ten. Nothing is breaking for existing users.
+
+The first two items changed contracts the rest build on — the frontmatter schema and the shape of a
+body fetch — so the table is ordered by dependency rather than by value.
 
 | Item | Theme | Package(s) | Notes |
 |---|---|---|---|
-| Selection metadata | Correctness | `agentskills-core` | **Implemented, awaiting release.** Optional `when_to_use` / `when_not_to_use` frontmatter, each a list of at most five 200-character entries. False activation is as damaging as non-activation, and a description alone carries no negative signal. Rendered in both catalog formats and omitted when absent; `get_skills_catalog(selection_hints=False)` trades the accuracy back for tokens. Optional and backward-compatible per principle 1; still to be pushed upstream. |
-| Section-level disclosure | Agent effectiveness | `agentskills-core` + integrations | **Implemented, awaiting release.** `get_skill_body()` is all-or-nothing, so a thorough 4k-token skill is charged in full to use one section. Split the body by heading, return an outline plus `get_skill_section(skill_id, heading)`. Extends progressive disclosure one level inward rather than adding a new idea, and stops penalising well-written skills. |
-| Semantic skill selection | Agent effectiveness | new `agentskills-retrieval` | **Implemented, awaiting release.** The catalog is injected on every turn, so prompt cost is linear in registered skills. Embed descriptions once, select top-k against the current turn, inject a handful. Descriptions are already written to be discriminative, so the corpus exists for free. Ships with a zero-dependency lexical default; embeddings are pluggable. Opt-in, and it must log its selection — this trades a deterministic prompt for a better one. |
-| Stateful / session-aware disclosure | Agent effectiveness | `agentskills-agentframework` | **Implemented, awaiting release.** The provider re-injected the whole catalog on every turn regardless of what the agent had already read. `after_run` now records full-body loads in session `state`, and later turns prune those entries down to a one-line reminder — caching saves provider I/O, but pruning is what makes turn N+1 cheaper. Declines to prune when the reminder would cost more than the entries, and never prunes to an empty catalog. Topic-based pruning was left out: that is semantic selection again, and it belongs in `agentskills-retrieval`. |
-| Single-skill fast path | Performance | `agentskills-core` + integrations | **Implemented, awaiting release.** A catalog exists to let a model choose; with one skill there is nothing to choose, so `resolve_fast_path()` inlines the body and drops the catalog, the usage instructions and the four body-access tools, removing a whole model round trip. Triggers on the *effective* set, so a registry narrowed to one by retrieval qualifies too. The token ceiling defaults to the size below which the fast path wins at any conversation length rather than to a guess; measured saving is 38-49% for a small skill. Resource tools stay — a skill carrying a 2 MB dataset must not have it inlined because the skill count happened to be one. |
-| Vision-native assets | Agent effectiveness | `agentskills-core` + integrations | **Implemented, awaiting release.** A base64 envelope is the right answer for an opaque binary and the wrong one for a diagram — the model got a wall of characters where a picture was. One classifier in core decides which is which; the three integrations differ only in how they wrap the result. Detection reads magic bytes before the filename, because a name is a claim and bytes are evidence. Native delivery is opt-in via `vision=True`, since handing an image to a text-only model is an API error rather than a worse answer, and no integration can ask a model whether it can see. Images get their own 5 MiB ceiling: the 64 KiB cap tracks tokens, and a native image is billed by tile count instead. PDF and SVG are excluded, and everything non-renderable keeps the v0.3 envelope unchanged. |
+| Selection metadata | Correctness | `agentskills-core` | Optional `when_to_use` / `when_not_to_use` frontmatter, each a list of at most five 200-character entries. False activation is as damaging as non-activation, and a description alone carries no negative signal. Rendered in both catalog formats and omitted when absent; `get_skills_catalog(selection_hints=False)` trades the accuracy back for tokens. Optional and backward-compatible per principle 1; still to be pushed upstream. |
+| Section-level disclosure | Agent effectiveness | `agentskills-core` + integrations | `get_skill_body()` is all-or-nothing, so a thorough 4k-token skill is charged in full to use one section. Split the body by heading, return an outline plus `get_skill_section(skill_id, heading)`. Extends progressive disclosure one level inward rather than adding a new idea, and stops penalising well-written skills. |
+| Semantic skill selection | Agent effectiveness | new `agentskills-retrieval` | The catalog is injected on every turn, so prompt cost is linear in registered skills. Embed descriptions once, select top-k against the current turn, inject a handful. Descriptions are already written to be discriminative, so the corpus exists for free. Ships with a zero-dependency lexical default; embeddings are pluggable. Opt-in, and it must log its selection — this trades a deterministic prompt for a better one. |
+| Stateful / session-aware disclosure | Agent effectiveness | `agentskills-agentframework` | The provider re-injected the whole catalog on every turn regardless of what the agent had already read. `after_run` now records full-body loads in session `state`, and later turns prune those entries down to a one-line reminder — caching saves provider I/O, but pruning is what makes turn N+1 cheaper. Declines to prune when the reminder would cost more than the entries, and never prunes to an empty catalog. Topic-based pruning was left out: that is semantic selection again, and it belongs in `agentskills-retrieval`. |
+| Single-skill fast path | Performance | `agentskills-core` + integrations | A catalog exists to let a model choose; with one skill there is nothing to choose, so `resolve_fast_path()` inlines the body and drops the catalog, the usage instructions and the four body-access tools, removing a whole model round trip. Triggers on the *effective* set, so a registry narrowed to one by retrieval qualifies too. The token ceiling defaults to the size below which the fast path wins at any conversation length rather than to a guess; measured saving is 38-49% for a small skill. Resource tools stay — a skill carrying a 2 MB dataset must not have it inlined because the skill count happened to be one. |
+| Vision-native assets | Agent effectiveness | `agentskills-core` + integrations | A base64 envelope is the right answer for an opaque binary and the wrong one for a diagram — the model got a wall of characters where a picture was. One classifier in core decides which is which; the three integrations differ only in how they wrap the result. Detection reads magic bytes before the filename, because a name is a claim and bytes are evidence. Native delivery is opt-in via `vision=True`, since handing an image to a text-only model is an API error rather than a worse answer, and no integration can ask a model whether it can see. Images get their own 5 MiB ceiling: the 64 KiB cap tracks tokens, and a native image is billed by tile count instead. PDF and SVG are excluded, and everything non-renderable keeps the v0.3 envelope unchanged. |
 
 ---
 
-## Next — v0.6 "Trust & Operability"
+## Now — v0.6 "Trust & Operability"
 
 The enterprise story. This is the work that makes the SDK viable as the substrate for
 [Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub).
@@ -136,7 +139,7 @@ The enterprise story. This is the work that makes the SDK viable as the substrat
 
 ---
 
-## Later — v0.7 "Ecosystem"
+## Next — v0.7 "Ecosystem"
 
 Breadth, once the core contracts are stable enough that each new package is cheap to add.
 
@@ -145,7 +148,7 @@ Breadth, once the core contracts are stable enough that each new package is chea
 | Skills as MCP prompts | Interoperability | The MCP server exposes skills as tools only. Many clients surface *prompts* as slash commands, so the same registry becomes user-invocable in Claude Desktop, VS Code, and others for very little work. |
 | Git provider | Ecosystem | Most skills live in Git repos. Clone/fetch with ref or commit pinning, sparse checkout, local cache. Likely the single most requested provider. |
 | Object storage provider | Ecosystem | S3 / Azure Blob / GCS via a common abstraction, with native credential chains instead of hand-rolled headers. |
-| OCI artifact provider | Ecosystem | Skills as OCI artifacts in any container registry — inherits existing signing, replication, and RBAC infrastructure. Pairs naturally with the integrity work in v0.5. |
+| OCI artifact provider | Ecosystem | Skills as OCI artifacts in any container registry — inherits existing signing, replication, and RBAC infrastructure. Pairs naturally with the integrity work in v0.6. |
 | Database provider | Ecosystem | Reference implementation over SQL for teams storing skills in an existing system of record. |
 | OpenAI Agents SDK integration | Ecosystem | Notable gap in the current integration matrix. |
 | Additional framework adapters | Ecosystem | Pydantic AI, Semantic Kernel, LlamaIndex, CrewAI. Prioritize by inbound demand rather than building all of them speculatively. |

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -10,9 +10,9 @@ Each file covers one milestone, in the same order as the corresponding roadmap t
 
 | Milestone | Items | State |
 |---|---|---|
-| [v0.3 — Foundations](./v0.3.md) | 12 | Specified |
-| [v0.4 — Developer Experience](./v0.4.md) | 12 | Specified |
-| [v0.5 — Agent Effectiveness](./v0.5.md) | 6 | Specified |
+| [v0.3 — Foundations](./v0.3.md) | 12 | Shipped |
+| [v0.4 — Developer Experience](./v0.4.md) | 12 | Shipped |
+| [v0.5 — Agent Effectiveness](./v0.5.md) | 6 | Shipped |
 | v0.6 — Trust & Operability | — | Not specified; see the [roadmap](../ROADMAP.md) |
 | v0.7 — Ecosystem | — | Not specified; see the [roadmap](../ROADMAP.md) |
 | v1.0 — Stability | — | Not specified; see the [roadmap](../ROADMAP.md) |

--- a/docs/issues/v0.5.md
+++ b/docs/issues/v0.5.md
@@ -16,8 +16,8 @@ once those land.
 
 **Labels:** `theme:correctness`, `type:feature`, `package:core`
 
-> **Status: implemented.** All four open questions were resolved; see the implementation notes.
-> The upstream proposal is still outstanding.
+> **Status: shipped in v0.5.0.** All four open questions were resolved; see the implementation
+> notes. The upstream proposal was evaluated and deferred — see the acceptance criteria.
 
 ### Problem
 
@@ -115,7 +115,11 @@ than kept as a local extension.
 - [x] A skill written before this change validates and renders unchanged
 - [x] `inspect --turn-budget` counts them; `lint` warns when both are missing
 - [x] Fields documented in the concepts page
-- [ ] Design proposed upstream to the Agent Skills specification
+- [x] Upstream proposal evaluated — **deferred, and deliberately not filed.** The specification
+  already treats `description` as the mechanism for activation boundaries, and documents an
+  optimization loop for tuning it against near-miss queries. Proposing structured fields therefore
+  needs trigger-rate data showing they beat a tuned description, and we do not have that data.
+  Retained as an optional local extension; revisit with measurements rather than argument.
 
 ### Implementation notes
 
@@ -165,7 +169,7 @@ should cost a skill its hint, not its place in the catalog — the same shape as
 
 **Labels:** `theme:agent-effectiveness`, `type:feature`, `package:core`, `package:langchain`, `package:agentframework`, `package:mcp-server`
 
-> **Status: implemented.** All four open questions were resolved; see the implementation notes.
+> **Status: shipped in v0.5.0.** All four open questions were resolved; see the implementation notes.
 > One documented deviation from the proposal: `get_outline()` returns a `SkillOutline`, not a
 > bare `list[SectionRef]`.
 
@@ -293,7 +297,7 @@ dependency.
 
 **Depends on:** item 1 (selection metadata supplies the corpus)
 
-> **Status: implemented.** All five open questions were resolved; see the implementation notes.
+> **Status: shipped in v0.5.0.** All five open questions were resolved; see the implementation notes.
 > One documented deviation from the proposal: this **did** require a change to
 > `agentskills-core` — a single optional `total=` keyword on `get_skills_catalog()` — because two
 > of the acceptance criteria could not otherwise both hold. The reasoning is in the notes.
@@ -458,7 +462,7 @@ thing `EmbeddingSelector` is for.
 
 **Labels:** `theme:agent-effectiveness`, `type:feature`, `package:agentframework`
 
-> **Status: implemented** — sub-items (a), (b), (f) and the load-driven half of (d).
+> **Status: shipped in v0.5.0** — sub-items (a), (b), (f) and the load-driven half of (d).
 > (c), (e), (g) and (h) are deferred with reasons; see the implementation notes.
 
 ### Problem
@@ -600,7 +604,7 @@ sniffing model families from a handle whose shape is not stable.
 
 **Depends on:** item 3 (the selected set, not just the registered set)
 
-> **Status: implemented.** All four open questions were resolved; see the implementation notes.
+> **Status: shipped in v0.5.0.** All four open questions were resolved; see the implementation notes.
 > One documented deviation: the opt-in is a resolved `FastPath` value rather than a boolean
 > flag, because resolution is async and two of the three entry points are sync. The reasoning
 > is in the notes.
@@ -759,7 +763,7 @@ is in the prompt, so there is nothing left to cache against and nothing to prune
 
 **Depends on:** the binary-safe resource envelope shipped in v0.3
 
-> **Status: implemented.** All four open questions were resolved; see the implementation
+> **Status: shipped in v0.5.0.** All four open questions were resolved; see the implementation
 > notes. Native delivery is opt-in via `vision=True`, so the default behaviour is byte-for-byte
 > what it was and the return-type widening is not a breaking change. Recorded as
 > [ADR 0009](../adr/0009-native-image-content.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,11 @@ nav:
       - Testing toolkit: packages/testing.md
   - Roadmap: ROADMAP.md
   - ADRs: adr/README.md
-  - v0.4 issue plan: issues/v0.4.md
+  - Issue plans:
+      - Overview: issues/README.md
+      - v0.5 Agent Effectiveness: issues/v0.5.md
+      - v0.4 Developer Experience: issues/v0.4.md
+      - v0.3 Foundations: issues/v0.3.md
   - Development: DEVELOPMENT.md
 
 plugins:


### PR DESCRIPTION
Post-release documentation pass. No code, no package changes.

## The actual defect

`docs/issues/v0.5.md` was never added to the MkDocs nav, so the most substantial writing in the milestone was unreachable from the published site. `issues/README.md` and `issues/v0.3.md` were missing too — only v0.4 had an entry. Replaced that single entry with an **Issue plans** section covering the index and all three shipped milestones.

## Roadmap

- v0.5 moves from `Now` to `Shipped`, with a release date and the same "N new distributions, nothing breaking" note the v0.3 and v0.4 sections carry.
- The six item rows drop their `**Implemented, awaiting release.**` prefix. They are released.
- v0.6 advances to `Now`, v0.7 to `Next`.
- Corrected the v0.7 OCI artifact row, which said it "pairs naturally with the integrity work in **v0.5**". Skill integrity is a **v0.6** item — leftover from a milestone renumbering, unrelated to this release.

## Issue plan status

- All six `**Status: implemented**` lines become `**Status: shipped in v0.5.0**`, matching the convention `issues/README.md` documents.
- The index `State` column reads `Shipped` for v0.3/v0.4/v0.5 instead of `Specified`.
- Item 1's last acceptance criterion was `- [ ] Design proposed upstream to the Agent Skills specification`. That work was evaluated and dropped, so rather than tick it falsely or leave a box that looks forgotten, the criterion is reworded to what was actually done and carries the reasoning: the specification already treats `description` as the mechanism for activation boundaries and documents an optimization loop for tuning it against near-miss queries, so proposing structured fields needs trigger-rate data showing they beat a tuned description. We do not have that data. The fields remain an optional local extension.

## Verification

`mkdocs` is not installed locally, so the strict build is left to CI. Checked by hand that every relative link in the three newly published pages resolves to a file that exists (`../adr/0007-…`, `../adr/0009-…`, `../DEVELOPMENT.md`, `../ROADMAP.md`, `./v0.3.md`, `./v0.4.md`, `./v0.5.md`) and that `mkdocs.yml` still parses, with the new nav section deserialising as expected.
