### PR TITLE
fix(ci): fetch gh-pages before mike deploys docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,6 +79,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
+      # mike rewrites gh-pages. Without a local copy of the existing branch its
+      # push is a non-fast-forward and is rejected, which is why every deploy
+      # after the one that first created gh-pages failed. Not shallow: pushing a
+      # shallow branch back is rejected as a shallow update.
+      - name: Fetch existing gh-pages
+        run: git fetch origin gh-pages:gh-pages || true
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
The v0.5.0 docs deploy failed. The published site still serves **0.4.0** — `versions.json` lists that and nothing else — so none of the v0.5 documentation is live, including the pages #133 just added to the nav.

## Diagnosis

The deploy job ended with:

```
error: failed to push branch gh-pages to origin:
 ! [rejected]        gh-pages -> gh-pages (fetch first)
```

`actions/checkout` fetches only the ref being built, so `gh-pages` is not present on the runner. `mike` consequently built a fresh branch with no history in common with the remote one and tried to push it, which is a non-fast-forward.

This passed exactly once — for v0.4.0 — because that run *created* `gh-pages` from nothing, making the push trivially a fast-forward. Every deploy after it was going to fail the same way. This run was the first `workflow_run`-triggered deploy, so the bug had never been exercised until the v0.5.0 tag.

## Fix

Fetch the branch before `mike` runs.

The fetch is deliberately **not** shallow: pushing a shallow branch back to GitHub is rejected as a shallow update, which would trade one push failure for another. `|| true` keeps a genuine first-time deploy working, where `gh-pages` does not exist yet.

## After merge

The deploy job also accepts `workflow_dispatch` with an explicit version, so `0.5.0` can be published without re-tagging. That path checks out `github.ref`, which is `main` — the v0.5.0 tree plus the doc corrections from #133 — so it deploys the content the site should be showing.
