### PR TITLE
docs: describe the control plane generically instead of linking it

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -122,8 +122,8 @@ body fetch — so the table is ordered by dependency rather than by value.
 
 ## Now — v0.6 "Trust & Operability"
 
-The enterprise story. This is the work that makes the SDK viable as the substrate for
-[Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub).
+The enterprise story. This is the work that makes the SDK viable as the substrate for a control
+plane that publishes skills centrally and governs who may use which version.
 
 | Item | Theme | Package(s) | Notes |
 |---|---|---|---|
@@ -173,7 +173,8 @@ Stating these prevents recurring proposals and scope creep.
 
 - **Executing skill scripts.** The SDK retrieves scripts; it does not run them. Sandboxed
   execution is the host application's responsibility. We will document the hazard, not own it.
-- **Authoring or hosting UI.** That is [Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub)'s job.
+- **Authoring or hosting UI.** That belongs to a control plane built on top of the SDK, not to the
+  SDK itself.
 - **Authentication and authorization.** Providers accept caller-supplied credentials. The SDK
   is not an identity or policy system.
 - **Being an agent framework.** We integrate with frameworks; we do not compete with them.

--- a/docs/issues/v0.3.md
+++ b/docs/issues/v0.3.md
@@ -350,9 +350,8 @@ non-MCP integrations.
 
 ### Problem
 
-Skills have no version. Consumers cannot pin, compare, or detect drift, and
-[Agent Skills Hub](https://github.com/pratikxpanda/agentskills-hub) needs versioned publishing
-and subscription pinning.
+Skills have no version. Consumers cannot pin, compare, or detect drift, and any system that
+publishes skills centrally needs versioned publishing and subscription pinning.
 
 ### Proposal
 


### PR DESCRIPTION
The Hub repository is moving out of public GitHub. Three places in the docs linked to it and would have become 404s:

- `docs/ROADMAP.md` - the v0.6 preamble
- `docs/ROADMAP.md` - the non-goals list
- `docs/issues/v0.3.md` - the versioning problem statement

None of the three claims needed the reader to open that repository, so each now names the capability rather than the project. No behaviour change; docs only.